### PR TITLE
DB-4072: [decoupled-preview] Save revision and redirect to preview site

### DIFF
--- a/css/add-icon.css
+++ b/css/add-icon.css
@@ -1,25 +1,25 @@
 #wp-admin-bar-decoupled-preview {
-  list-style-type: none;
+	list-style-type: none;
 }
 
 #wp-admin-bar-decoupled-preview > .ab-sub-wrapper {
-  position: absolute;
-  top: 100%;
-  height: auto;
+	position: absolute;
+	top: 100%;
+	height: auto;
 }
 #wp-admin-bar-decoupled-preview > .ab-sub-wrapper > ul {
-  display: flex;
-  flex-direction: column;
-  margin: 0;
+	display: flex;
+	flex-direction: column;
+	margin: 0;
 }
 
 #wp-admin-bar-decoupled-preview > .ab-sub-wrapper > ul > li {
-  border-bottom: 1px groove;
+	border-bottom: 1px groove;
 }
 
 #wp-admin-bar-decoupled-preview > .ab-sub-wrapper > ul > li:last-child {
-  border-bottom: none;
+	border-bottom: none;
 }
 .interface-z-index-0 {
-  z-index: 0;
+	z-index: 0;
 }

--- a/js/add-new-preview-btn.js
+++ b/js/add-new-preview-btn.js
@@ -9,24 +9,23 @@
 window.addEventListener(
 	"load",
 	() => {
-    const previewBlock        = document.querySelector( ".block-editor-post-preview__dropdown" );
-    const decoupledPreviewBtn = document.getElementById( 'wp-admin-bar-decoupled-preview' );
-    // Remove the old Preview button.
+		const previewBlock    	  = document.querySelector( ".block-editor-post-preview__dropdown" );
+		const decoupledPreviewBtn = document.getElementById( 'wp-admin-bar-decoupled-preview' );
+		// Remove the old Preview button.
 		previewBlock.removeChild( previewBlock.querySelector( 'button' ) );
-    // Add Decoupled Preview Button into the same Preview continer.
+		// Add Decoupled Preview Button into the same Preview continer.
 		previewBlock.appendChild( decoupledPreviewBtn );
-    // Hide submenu items by default.
+		// Hide submenu items by default.
 		const previewSubmenu = decoupledPreviewBtn.querySelector( ".ab-sub-wrapper" );
-    previewSubmenu.classList.add( "hidden" )
-
+		previewSubmenu.classList.add( "hidden" );
 		// Add event listener to toggle submenu items.
 		decoupledPreviewBtn.addEventListener(
 			"click",
 			(e) => {
-        wp.data.dispatch('core/editor').autosave();
-        previewSubmenu.classList.toggle( "hidden" );
-        previewSubmenu.classList.toggle( "components-popover__content" );
-        // Change the edit post side bar z-index.
+				wp.data.dispatch( 'core/editor' ).autosave();
+				previewSubmenu.classList.toggle( "hidden" );
+				previewSubmenu.classList.toggle( "components-popover__content" );
+				// Change the edit post side bar z-index.
 				document.querySelector( '.interface-interface-skeleton__sidebar' ).classList.toggle( 'interface-z-index-0' );
 			}
 		);

--- a/js/add-new-preview-btn.js
+++ b/js/add-new-preview-btn.js
@@ -23,9 +23,10 @@ window.addEventListener(
 		decoupledPreviewBtn.addEventListener(
 			"click",
 			(e) => {
-            previewSubmenu.classList.toggle( "hidden" );
-            previewSubmenu.classList.toggle( "components-popover__content" );
-            // Change the edit post side bar z-index.
+        wp.data.dispatch('core/editor').autosave();
+        previewSubmenu.classList.toggle( "hidden" );
+        previewSubmenu.classList.toggle( "components-popover__content" );
+        // Change the edit post side bar z-index.
 				document.querySelector( '.interface-interface-skeleton__sidebar' ).classList.toggle( 'interface-z-index-0' );
 			}
 		);

--- a/src/class-decoupled-preview-settings.php
+++ b/src/class-decoupled-preview-settings.php
@@ -29,26 +29,26 @@ if ( ! class_exists( 'Decoupled_Preview_Settings' ) ) {
 		 * @return void
 		 */
 		public function admin_init() {
-			register_setting( 'wp-decoupled-preview', 'preview_sites', [ $this, 'sanitize_callback_preview' ] );
+			register_setting( 'wp-decoupled-preview', 'preview_sites', array( $this, 'sanitize_callback_preview' ) );
 
 			add_settings_section(
 				'wp-decoupled-preview-section',
 				'Create/Edit Preview Sites',
-				[ &$this, 'settings_section_wp_decoupled_preview' ],
+				array( &$this, 'settings_section_wp_decoupled_preview' ),
 				'preview_sites'
 			);
 
 			add_settings_field(
 				'plugin_text_label',
 				'Label',
-				[ &$this, 'setting_label_fn' ],
+				array( &$this, 'setting_label_fn' ),
 				'preview_sites',
 				'wp-decoupled-preview-section'
 			);
-			add_settings_field( 'plugin_text_url', 'URL', [ &$this, 'setting_url_fn' ], 'preview_sites', 'wp-decoupled-preview-section' );
-			add_settings_field( 'plugin_text_secret', 'Secret', [ &$this, 'setting_secret_fn' ], 'preview_sites', 'wp-decoupled-preview-section' );
-			add_settings_field( 'plugin_drop_down', 'Preview Type', [ &$this, 'setting_preview_type_fn' ], 'preview_sites', 'wp-decoupled-preview-section' );
-			add_settings_field( 'plugin_checkbox', 'Content Type', [ &$this, 'setting_content_type_fn' ], 'preview_sites', 'wp-decoupled-preview-section' );
+			add_settings_field( 'plugin_text_url', 'URL', array( &$this, 'setting_url_fn' ), 'preview_sites', 'wp-decoupled-preview-section' );
+			add_settings_field( 'plugin_text_secret', 'Secret', array( &$this, 'setting_secret_fn' ), 'preview_sites', 'wp-decoupled-preview-section' );
+			add_settings_field( 'plugin_drop_down', 'Preview Type', array( &$this, 'setting_preview_type_fn' ), 'preview_sites', 'wp-decoupled-preview-section' );
+			add_settings_field( 'plugin_checkbox', 'Content Type', array( &$this, 'setting_content_type_fn' ), 'preview_sites', 'wp-decoupled-preview-section' );
 
 		}
 
@@ -64,7 +64,7 @@ if ( ! class_exists( 'Decoupled_Preview_Settings' ) ) {
 				__( 'Settings', 'wp-graphql' ),
 				'manage_options',
 				'add_preview_site',
-				[ $this, 'wp_decoupled_preview_create_html' ]
+				array( $this, 'wp_decoupled_preview_create_html' )
 			);
 		}
 
@@ -79,7 +79,7 @@ if ( ! class_exists( 'Decoupled_Preview_Settings' ) ) {
 				'Preview Sites',
 				'manage_options',
 				'preview_sites',
-				[ &$this, 'wp_decoupled_preview_list_html' ]
+				array( &$this, 'wp_decoupled_preview_list_html' )
 			);
 		}
 
@@ -164,12 +164,12 @@ if ( ! class_exists( 'Decoupled_Preview_Settings' ) ) {
 									<?php
 									echo wp_kses(
 										$data,
-										[
-											'a' => [
-												'href'  => [],
-												'title' => [],
-											],
-										]
+										array(
+											'a' => array(
+												'href'  => array(),
+												'title' => array(),
+											),
+										)
 									);
 									?>
 										</td>
@@ -217,7 +217,7 @@ if ( ! class_exists( 'Decoupled_Preview_Settings' ) ) {
 			}
 
 			if ( $options && $input && ! isset( $options['preview'][1]['label'] ) ) {
-				return [ 'preview' => [ 1 => $input ] ];
+				return array( 'preview' => array( 1 => $input ) );
 			} elseif ( $options && isset( $edit_id ) ) {
 				$options['preview'][ $edit_id ] = $input;
 				return $options;
@@ -244,8 +244,8 @@ if ( ! class_exists( 'Decoupled_Preview_Settings' ) ) {
 		 */
 		public function get_edit_id() {
 			// TODO: Processing form data with nonce verification.
-			if ( $_GET['edit'] ) {
-				return $_GET['edit'];
+			if ( isset( $_GET['edit'] ) && sanitize_text_field( wp_unslash( $_GET['edit'] ) ) ) {
+				return sanitize_text_field( wp_unslash( $_GET['edit'] ) );
 			}
 			return null;
 		}
@@ -261,17 +261,17 @@ if ( ! class_exists( 'Decoupled_Preview_Settings' ) ) {
 			$value   = isset( $edit_id ) ? $site['label'] : '';
 			echo wp_kses(
 				"<input id='plugin_text_lable' name='preview_sites[label]' size='60' type='text'  value='{$value}' required /><br>[Required] Label for the preview site.",
-				[
-					'input' => [
-						'id'       => [],
-						'name'     => [],
-						'size'     => [],
-						'type'     => [],
-						'value'    => [],
-						'required' => [],
-					],
-					'br'    => [],
-				]
+				array(
+					'input' => array(
+						'id'       => array(),
+						'name'     => array(),
+						'size'     => array(),
+						'type'     => array(),
+						'value'    => array(),
+						'required' => array(),
+					),
+					'br'    => array(),
+				)
 			);
 		}
 
@@ -286,17 +286,17 @@ if ( ! class_exists( 'Decoupled_Preview_Settings' ) ) {
 			$value   = isset( $edit_id ) ? $site['url'] : '';
 			echo wp_kses(
 				"<input id='plugin_text_url' name='preview_sites[url]' size='60' type='url' value='{$value}' required /><br>[Required] URL for the preview site.",
-				[
-					'input' => [
-						'id'       => [],
-						'name'     => [],
-						'size'     => [],
-						'type'     => [],
-						'value'    => [],
-						'required' => [],
-					],
-					'br'    => [],
-				]
+				array(
+					'input' => array(
+						'id'       => array(),
+						'name'     => array(),
+						'size'     => array(),
+						'type'     => array(),
+						'value'    => array(),
+						'required' => array(),
+					),
+					'br'    => array(),
+				)
 			);
 		}
 
@@ -310,17 +310,17 @@ if ( ! class_exists( 'Decoupled_Preview_Settings' ) ) {
 			$html    = isset( $edit_id ) ? "<input id='plugin_text_secret' name='preview_sites[secret_string]' size='40' type='password' /><br>Shared secret for the preview site. When editing, if kept empty the old value will be saved, otherwise it will be overwritten." : "<input id='plugin_text_secret' name='preview_sites[secret_string]' size='40' type='password' required /><br>[Required] Shared secret for the preview site.";
 			echo wp_kses(
 				$html,
-				[
-					'input' => [
-						'id'       => [],
-						'name'     => [],
-						'size'     => [],
-						'type'     => [],
-						'value'    => [],
-						'required' => [],
-					],
-					'br'    => [],
-				]
+				array(
+					'input' => array(
+						'id'       => array(),
+						'name'     => array(),
+						'size'     => array(),
+						'type'     => array(),
+						'value'    => array(),
+						'required' => array(),
+					),
+					'br'    => array(),
+				)
 			);
 		}
 
@@ -332,39 +332,39 @@ if ( ! class_exists( 'Decoupled_Preview_Settings' ) ) {
 		public function setting_preview_type_fn() {
 			$edit_id = $this->get_edit_id();
 			$site    = $this->get_preview_site( $edit_id );
-			$items   = [ 'Next.js' ];
+			$items   = array( 'Next.js' );
 			echo wp_kses(
 				"<select id='preview_type' name='preview_sites[preview_type]' required>",
-				[
-					'select' => [
-						'id'       => [],
-						'name'     => [],
-						'required' => [],
-					],
-				]
+				array(
+					'select' => array(
+						'id'       => array(),
+						'name'     => array(),
+						'required' => array(),
+					),
+				)
 			);
 			foreach ( $items as $item ) {
 				$selected = ( $site['preview_type'] === $item ) ? 'selected="selected"' : '';
 				echo wp_kses(
 					"<option value='$item' $selected>$item</option>",
-					[
-						'option' => [
-							'value' => [],
-						],
-					]
+					array(
+						'option' => array(
+							'value' => array(),
+						),
+					)
 				);
 			}
 			echo wp_kses(
 				'</select>',
-				[
-					'select' => [],
-				]
+				array(
+					'select' => array(),
+				)
 			);
 			echo wp_kses(
 				'<br>[Required] Preview type for the front-end.',
-				[
-					'br' => [],
-				]
+				array(
+					'br' => array(),
+				)
 			);
 		}
 
@@ -375,41 +375,41 @@ if ( ! class_exists( 'Decoupled_Preview_Settings' ) ) {
 		 */
 		public function setting_content_type_fn() {
 			$edit_id = $this->get_edit_id();
-			$items   = [ 'Post', 'Page' ];
+			$items   = array( 'Post', 'Page' );
 			$site    = $this->get_preview_site( $edit_id );
 			foreach ( $items as $item ) {
 				if ( isset( $edit_id ) && isset( $site['content_type'] ) ) {
 					$checked = ( in_array( strtolower( $item ), $site['content_type'], true ) ) ? ' checked="checked" ' : '';
 					echo wp_kses(
 						'<label> <input ' . $checked . " value='$item' name='preview_sites[content_type][]' type='checkbox' /> $item </label><br />",
-						[
-							'input' => [
-								'id'      => [],
-								'checked' => [],
-								'name'    => [],
-								'size'    => [],
-								'type'    => [],
-								'value'   => [],
-							],
-							'br'    => [],
-							'label' => [],
-						]
+						array(
+							'input' => array(
+								'id'      => array(),
+								'checked' => array(),
+								'name'    => array(),
+								'size'    => array(),
+								'type'    => array(),
+								'value'   => array(),
+							),
+							'br'    => array(),
+							'label' => array(),
+						)
 					);
 				} else {
 					echo wp_kses(
 						"<label> <input value='$item' name='preview_sites[content_type][]' type='checkbox' /> $item </label><br />",
-						[
-							'input' => [
-								'id'      => [],
-								'checked' => [],
-								'name'    => [],
-								'size'    => [],
-								'type'    => [],
-								'value'   => [],
-							],
-							'br'    => [],
-							'label' => [],
-						]
+						array(
+							'input' => array(
+								'id'      => array(),
+								'checked' => array(),
+								'name'    => array(),
+								'size'    => array(),
+								'type'    => array(),
+								'value'   => array(),
+							),
+							'br'    => array(),
+							'label' => array(),
+						)
 					);
 				}
 			}
@@ -424,7 +424,7 @@ if ( ! class_exists( 'Decoupled_Preview_Settings' ) ) {
 		 * @return array
 		 *   Return a list of sites | Only a specific site.
 		 */
-		public function get_preview_site( int $id = NULL ): ?array {
+		public function get_preview_site( int $id = null ): ?array {
 			$preview_sites = get_option( 'preview_sites' );
 			if ( $preview_sites && isset( $preview_sites['preview'][1]['label'] ) ) {
 				$preview_sites = array_shift( $preview_sites );
@@ -446,7 +446,7 @@ if ( ! class_exists( 'Decoupled_Preview_Settings' ) ) {
 		 */
 		public function get_enabled_site_by_post_type( string $post_type ): ?array {
 			$sites        = $this->get_preview_site();
-			$enable_sites = [];
+			$enable_sites = array();
 			if ( ! empty( $sites ) ) {
 				foreach ( $sites as $site ) {
 					if ( empty( $site['content_type'] ) || in_array( $post_type, $site['content_type'], true ) ) {

--- a/templates/preview-template.php
+++ b/templates/preview-template.php
@@ -1,10 +1,14 @@
 <?php
 
 // Assemble necessary params for preview API route
-// TODO - Check Nonce and Sanitize
 
-$preview_id = $_GET['preview_id'];
-$preview_site_id = $_GET['decoupled_preview_site'];
+$preview_id = sanitize_text_field( $_GET['preview_id'] );
+$preview_site_id = sanitize_text_field( $_GET['decoupled_preview_site'] );
+$nonce = sanitize_text_field( $_GET['preview_nonce'] );
+
+if ( ! wp_verify_nonce( $nonce, 'post_preview_' . $preview_id ) ) {
+    wp_die( 'Unable to preview: invalid nonce' );
+}
 
 $post = get_post( $preview_id );
 $revision = wp_get_post_autosave( $preview_id, get_current_user_id() );

--- a/templates/preview-template.php
+++ b/templates/preview-template.php
@@ -1,0 +1,37 @@
+<?php
+
+// TODO - Add code here to determine the appropriate preview URL to redirect to.
+// This should be similar to what we do to construct the URL for the menu.
+// $preview_api_url = ...
+
+$preview_id = $_GET['preview_id'];
+$revisions = wp_get_post_revisions( $post_id );
+print_r($revisions);
+?>
+
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<title>Decoupled Preview</title>
+
+	<!-- <script>
+		<?php
+			// if ( $preview_api_url ) {
+			// 	// Redirecting via JS because the page headers have already been set by the time we get into this template so PHP wont redirect.
+			// 	echo 'window.location.replace("'. $preview_api_url .'");';
+			// }
+		?>
+	</script> -->
+</head>
+
+<body>
+        <h1>Custom Preview</h1>
+        Preview ID: <?php echo $preview_id ?>
+</body>
+
+<?php wp_footer(); ?>
+
+</html>

--- a/templates/preview-template.php
+++ b/templates/preview-template.php
@@ -1,23 +1,26 @@
 <?php
+/**
+ * Assemble necessary params for preview API route
+ *
+ * @package wp-decoupled-preview
+ */
 
-// Assemble necessary params for preview API route
-
-$preview_id = sanitize_text_field( $_GET['preview_id'] );
-$preview_site_id = sanitize_text_field( $_GET['decoupled_preview_site'] );
-$nonce = sanitize_text_field( $_GET['preview_nonce'] );
+$preview_id      = isset( $_GET['preview_id'] ) ? sanitize_text_field( wp_unslash( $_GET['preview_id'] ) ) : false;
+$preview_site_id = isset( $_GET['decoupled_preview_site'] ) ? sanitize_text_field( wp_unslash( $_GET['decoupled_preview_site'] ) ) : false;
+$nonce           = isset( $_GET['preview_nonce'] ) ? sanitize_text_field( wp_unslash( $_GET['preview_nonce'] ) ) : false;
 
 if ( ! wp_verify_nonce( $nonce, 'post_preview_' . $preview_id ) ) {
-    wp_die( 'Unable to preview: invalid nonce' );
+	wp_die( 'Unable to preview: invalid nonce' );
 }
 
-$post = get_post( $preview_id );
-$revision = wp_get_post_autosave( $preview_id, get_current_user_id() );
-$post_type = get_post_type($post);
+$preview_post      = get_post( $preview_id );
+$revision          = wp_get_post_autosave( $preview_id, get_current_user_id() );
+$preview_post_type = get_post_type( $preview_post );
 
 $preview_helper = new Decoupled_Preview_Settings();
-$preview_site = $preview_helper->get_preview_site($preview_site_id);
+$preview_site   = $preview_helper->get_preview_site( $preview_site_id );
 
-$redirect = "{$preview_site['url']}?secret={$preview_site['secret_string']}&uri={$post->post_name}&id={$revision->ID}&content_type={$post_type}";
+$redirect = "{$preview_site['url']}?secret={$preview_site['secret_string']}&uri={$preview_post->post_name}&id={$revision->ID}&content_type={$preview_post_type}";
 ?>
 
 <html lang="en">
@@ -30,17 +33,17 @@ $redirect = "{$preview_site['url']}?secret={$preview_site['secret_string']}&uri=
 
 	<script>
 		<?php
-			if ( $preview_site['url'] ) {
-				// Redirecting via JS because the page headers have already been set by
-        // the time we get into this template so PHP wont redirect.
-				echo 'window.location.replace("'. $redirect .'");';
-			}
+		if ( $preview_site['url'] ) {
+			// Redirecting via JS because the page headers have already been set by
+			// the time we get into this template so PHP wont redirect.
+			echo 'window.location.replace("' . esc_url_raw( $redirect ) . '");';
+		}
 		?>
 	</script>
 </head>
 
 <body>
-  <h1>Redirecting to <?php echo $preview_site['label'] ?>...</h1>
+	<h1>Redirecting to preview site...</h1>
 </body>
 
 <?php wp_footer(); ?>

--- a/templates/preview-template.php
+++ b/templates/preview-template.php
@@ -1,12 +1,19 @@
 <?php
 
-// TODO - Add code here to determine the appropriate preview URL to redirect to.
-// This should be similar to what we do to construct the URL for the menu.
-// $preview_api_url = ...
+// Assemble necessary params for preview API route
+// TODO - Check Nonce and Sanitize
 
 $preview_id = $_GET['preview_id'];
-$revisions = wp_get_post_revisions( $post_id );
-print_r($revisions);
+$preview_site_id = $_GET['decoupled_preview_site'];
+
+$post = get_post( $preview_id );
+$revision = wp_get_post_autosave( $preview_id, get_current_user_id() );
+$post_type = get_post_type($post);
+
+$preview_helper = new Decoupled_Preview_Settings();
+$preview_site = $preview_helper->get_preview_site($preview_site_id);
+
+$redirect = "{$preview_site['url']}?secret={$preview_site['secret_string']}&uri={$post->post_name}&id={$revision->ID}&content_type={$post_type}";
 ?>
 
 <html lang="en">
@@ -17,19 +24,19 @@ print_r($revisions);
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>Decoupled Preview</title>
 
-	<!-- <script>
+	<script>
 		<?php
-			// if ( $preview_api_url ) {
-			// 	// Redirecting via JS because the page headers have already been set by the time we get into this template so PHP wont redirect.
-			// 	echo 'window.location.replace("'. $preview_api_url .'");';
-			// }
+			if ( $preview_site['url'] ) {
+				// Redirecting via JS because the page headers have already been set by
+        // the time we get into this template so PHP wont redirect.
+				echo 'window.location.replace("'. $redirect .'");';
+			}
 		?>
-	</script> -->
+	</script>
 </head>
 
 <body>
-        <h1>Custom Preview</h1>
-        Preview ID: <?php echo $preview_id ?>
+  <h1>Redirecting to <?php echo $preview_site['label'] ?>...</h1>
 </body>
 
 <?php wp_footer(); ?>

--- a/wp-decoupled-preview.php
+++ b/wp-decoupled-preview.php
@@ -61,6 +61,8 @@ function wp_decoupled_preview_delete_default_options() {
 	delete_option( 'preview_sites' );
 }
 
+new Decoupled_Preview_Settings();
+
 add_action(
 	'updated_option',
 	function( $option_name, $option_value ) {

--- a/wp-decoupled-preview.php
+++ b/wp-decoupled-preview.php
@@ -12,7 +12,13 @@
  * @package         Pantheon_Decoupled
  */
 
-require_once(ABSPATH . 'wp-admin/includes/post.php');
+/**
+ * Adjusts preview button to work with external decoupled preview sites.
+ *
+ * @package wp-decoupled-preview
+ */
+
+require_once ABSPATH . 'wp-admin/includes/post.php';
 require_once dirname( __FILE__ ) . '/src/class-decoupled-preview-settings.php';
 
 register_activation_hook( __FILE__, 'wp_decoupled_preview_default_options' );
@@ -27,9 +33,10 @@ if ( 'post.php' === $pagenow || 'post-new.php' === $pagenow ) {
 	add_action( 'wp_enqueue_scripts', 'enqueue_script' );
 	add_action( 'admin_enqueue_scripts', 'enqueue_script' );
 }
-if (isset($_GET['decoupled_preview_site'])) {
-  // Return custom preview template where we can handle redirect
-  add_filter( 'template_include', 'override_preview_template', 1);
+// Processing form data without nonce verification.
+if ( isset( $_GET['decoupled_preview_site'] ) ) {
+	// Return custom preview template where we can handle redirect.
+	add_filter( 'template_include', 'override_preview_template', 1 );
 }
 
 /**
@@ -40,15 +47,15 @@ if (isset($_GET['decoupled_preview_site'])) {
 function wp_decoupled_preview_default_options() {
 	add_option(
 		'preview_sites',
-		[
-			'preview' => [
-				1 => [
+		array(
+			'preview' => array(
+				1 => array(
 					'label'         => null,
 					'url'           => null,
 					'secret_string' => null,
-				],
-			],
-		]
+				),
+			),
+		)
 	);
 }
 
@@ -92,19 +99,19 @@ function add_admin_decoupled_preview_link( $admin_bar ) {
 		$enable_by_post_type = $preview_helper->get_enabled_site_by_post_type( $post_type );
 		if ( $sites && ! empty( $enable_by_post_type ) && ( ( 'post' === $post_type ) || ( 'page' === $post_type ) ) ) {
 			$admin_bar->add_menu(
-				[
+				array(
 					'id'    => 'decoupled-preview',
 					'title' => 'Decoupled Preview',
 					'href'  => false,
-					'meta'  => [
+					'meta'  => array(
 						'class' => 'components-button is-tertiary',
-					],
-				]
+					),
+				)
 			);
 
 			// Reinventing the wheel and creating the preview link as done in wp/wp-admin/includes/post.php.
 			$post_id                     = get_the_ID();
-			$post                        = get_post($post_id);
+			$post                        = get_post( $post_id );
 			$nonce                       = wp_create_nonce( 'post_preview_' . $post->ID );
 			$query_args['preview_id']    = $post->ID;
 			$query_args['preview_nonce'] = $nonce;
@@ -112,19 +119,19 @@ function add_admin_decoupled_preview_link( $admin_bar ) {
 			foreach ( $sites as $id => $site ) {
 				if ( ( ! isset( $site['content_type'] ) ) || ( in_array( $post_type, $site['content_type'], true ) ) ) {
 					$query_args['decoupled_preview_site'] = $id;
-					$preview_link = get_preview_post_link( $post->ID, $query_args );
+					$preview_link                         = get_preview_post_link( $post->ID, $query_args );
 					$admin_bar->add_menu(
-						[
+						array(
 							'id'     => 'preview-site-' . $id,
 							'parent' => 'decoupled-preview',
 							'title'  => $site['label'],
 							'href'   => $preview_link,
-							'meta'   => [
+							'meta'   => array(
 								'title'  => $site['label'],
 								'target' => '_blank',
 								'class'  => 'dashicons-before dashicons-external components-button components-menu-item__button',
-							],
-						]
+							),
+						)
 					);
 				}
 			}
@@ -143,7 +150,7 @@ function enqueue_style() {
 	$sites               = $preview_helper->get_preview_site();
 	$enable_by_post_type = $preview_helper->get_enabled_site_by_post_type( get_post_type() );
 	if ( $sites && ! empty( $enable_by_post_type ) ) {
-		wp_enqueue_style( 'add-icon', plugins_url( '/css/add-icon.css', __FILE__ ), [], 1.0 );
+		wp_enqueue_style( 'add-icon', plugins_url( '/css/add-icon.css', __FILE__ ), array(), 1.0 );
 	}
 }
 
@@ -157,10 +164,16 @@ function enqueue_script() {
 	$sites               = $preview_helper->get_preview_site();
 	$enable_by_post_type = $preview_helper->get_enabled_site_by_post_type( get_post_type() );
 	if ( $sites && ! empty( $enable_by_post_type ) ) {
-		wp_enqueue_script( 'add-new-preview-btn', plugins_url( '/js/add-new-preview-btn.js', __FILE__ ), [], 1.0, true );
+		wp_enqueue_script( 'add-new-preview-btn', plugins_url( '/js/add-new-preview-btn.js', __FILE__ ), array(), 1.0, true );
 	}
 }
 
-function override_preview_template($template) {
-  return trailingslashit( dirname( __FILE__ ) ) . 'templates/preview-template.php';
+/**
+ * Override preview template.
+ *
+ * @param string $template Template path.
+ * @return string
+ */
+function override_preview_template( $template ) {
+	return trailingslashit( dirname( __FILE__ ) ) . 'templates/preview-template.php';
 }


### PR DESCRIPTION
* Saves revision when decoupled preview button is clicked.
* Uses custom preview template to redirect to the appropriate preview API route.

Requires this update to the next-wordpress-starter to work end to end: https://github.com/pantheon-systems/decoupled-kit-js/pull/430