### PR TITLE
[CMSP-251] Decoupled Preview unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ vendor/
 
 # Ignore PHPUnit cache
 .phpunit.result.cache
+
+# Ignore Subversion files
+.svn/
+branches/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WP Decoupled Preview
 
 
-[![Actively Maintained](https://img.shields.io/badge/Pantheon-Actively_Maintained-yellow?logo=pantheon&color=FFDC28)](https://docs.pantheon.io/oss-support-levels#actively-maintained-support) [![Packagist Version](https://img.shields.io/packagist/v/pantheon-systems/wp-decoupled-preview)](https://packagist.org/packages/pantheon-systems/decoupled-preview) [![GPL 2.0 License](https://img.shields.io/github/license/pantheon-systems/wp-decoupled-preview)](https://github.com/pantheon-systems/wp-decoupled-preview/blob/main/LICENSE) [![Build Status](https://img.shields.io/github/actions/workflow/status/pantheon-systems/wp-decoupled-preview/lint-test.yml)](https://github.com/pantheon-systems/wp-decoupled-preview/actions)
+[![Actively Maintained](https://img.shields.io/badge/Pantheon-Actively_Maintained-yellow?logo=pantheon&color=FFDC28)](https://docs.pantheon.io/oss-support-levels#actively-maintained-support) [![Packagist Version](https://img.shields.io/packagist/v/pantheon-systems/decoupled-preview)](https://packagist.org/packages/pantheon-systems/decoupled-preview) [![GPL 2.0 License](https://img.shields.io/github/license/pantheon-systems/wp-decoupled-preview)](https://github.com/pantheon-systems/wp-decoupled-preview/blob/main/LICENSE) [![Build Status](https://img.shields.io/github/actions/workflow/status/pantheon-systems/wp-decoupled-preview/lint-test.yml)](https://github.com/pantheon-systems/wp-decoupled-preview/actions)
 
 
 Preview headless WordPress content on your front-end site.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Decoupled Preview
+# WP Decoupled Preview
+
+
+[![Actively Maintained](https://img.shields.io/badge/Pantheon-Actively_Maintained-yellow?logo=pantheon&color=FFDC28)](https://docs.pantheon.io/oss-support-levels#actively-maintained-support) [![Packagist Version](https://img.shields.io/packagist/v/pantheon-systems/wp-decoupled-preview)](https://packagist.org/packages/pantheon-systems/decoupled-preview) [![GPL 2.0 License](https://img.shields.io/github/license/pantheon-systems/wp-decoupled-preview)](https://github.com/pantheon-systems/wp-decoupled-preview/blob/main/LICENSE) [![Build Status](https://img.shields.io/github/actions/workflow/status/pantheon-systems/wp-decoupled-preview/lint-test.yml)](https://github.com/pantheon-systems/wp-decoupled-preview/actions)
+
 
 Preview headless WordPress content on your front-end site.
 

--- a/README.md
+++ b/README.md
@@ -32,3 +32,27 @@ NextJS sites using a similar approach.
 ## Known Issues
 
 - Currently this plugin does not support custom post types.
+
+## Linting and Testing
+
+This plugin uses [Composer](https://getcomposer.org/) to manage dependencies. To install dependencies, run `composer install` from the plugin directory. 
+
+Linting is done with [PHP_CodeSniffer](https://packagist.org/packages/squizlabs/php_codesniffer) using the [Pantheon WP Coding Standards](https://packagist.org/packages/pantheon-systems/pantheon-wp-coding-standards) ruleset. To run the linting checks, use the following command:
+
+```bash
+composer lint
+```
+
+Unit tests are written with [PHPUnit](https://packagist.org/packages/phpunit/phpunit) using the WP Unit test framework. To set up your local maching to be able to run the unit tests, use the following command:
+
+```bash
+composer test:install
+```
+
+Note that you will need to have MariaDB or MySQL installed and running on your local machine. Once you have the test environment set up, you can run the unit tests with the following command:
+
+```bash
+composer test
+```
+
+Both linting and testing are done in a GitHub Action on every commit and pull request. Tests are located in the `tests` directory.

--- a/src/class-decoupled-preview-settings.php
+++ b/src/class-decoupled-preview-settings.php
@@ -693,7 +693,7 @@ if ( ! class_exists( __NAMESPACE__ . '\\Decoupled_Preview_Settings' ) ) {
 			$enable_sites = [];
 			if ( ! empty( $sites ) ) {
 				foreach ( $sites['preview'] as $site ) {
-					if ( empty( $site['content_type'] ) || in_array( $post_type, $site['content_type'], true ) ) {
+					if ( ! isset( $site['content_type'] ) || isset( $site['content_type'] ) && in_array( $post_type, $site['content_type'], true ) ) {
 						$enable_sites[] = $site;
 					}
 				}

--- a/src/class-decoupled-preview-settings.php
+++ b/src/class-decoupled-preview-settings.php
@@ -692,8 +692,8 @@ if ( ! class_exists( __NAMESPACE__ . '\\Decoupled_Preview_Settings' ) ) {
 			$sites = $this->get_preview_site();
 			$enable_sites = [];
 			if ( ! empty( $sites ) ) {
-				foreach ( $sites as $site ) {
-					if ( empty( $site['content_type'] ) || in_array( $post_type, $site['content_type'], true ) ) {
+				foreach ( $sites['preview'] as $site ) {
+					if ( ! isset( $site['content_type'] ) || isset( $site['content_type'] ) && in_array( $post_type, $site['content_type'], true ) ) {
 						$enable_sites[] = $site;
 					}
 				}

--- a/src/class-decoupled-preview-settings.php
+++ b/src/class-decoupled-preview-settings.php
@@ -575,12 +575,13 @@ if ( ! class_exists( __NAMESPACE__ . '\\Decoupled_Preview_Settings' ) ) {
 			}
 
 			if ( $id ) {
+				if ( ! isset( $preview_sites['preview'][ $id ] ) ) {
+					return [];
+				}
+
 				return $preview_sites['preview'][ $id ];
 			}
 
-			if ( ! isset( $preview_sites['preview'][ $id ] ) ) {
-				return [];
-			}
 
 			return $preview_sites;
 		}

--- a/src/class-decoupled-preview-settings.php
+++ b/src/class-decoupled-preview-settings.php
@@ -418,7 +418,7 @@ if ( ! class_exists( __NAMESPACE__ . '\\Decoupled_Preview_Settings' ) ) {
 			}
 
 			// If we're adding a new site and have options, set the ID to one higher than the highest existing ID.
-			if ( $options && $edit_id === 0 ) {
+			if ( $options && $edit_id < 1 ) {
 				$edit_id = absint( max( wp_list_pluck( $options['preview'], 'id' ) ) ) + 1;
 			}
 

--- a/src/class-decoupled-preview-settings.php
+++ b/src/class-decoupled-preview-settings.php
@@ -578,6 +578,10 @@ if ( ! class_exists( __NAMESPACE__ . '\\Decoupled_Preview_Settings' ) ) {
 				return $preview_sites['preview'][ $id ];
 			}
 
+			if ( ! isset( $preview_sites['preview'][ $id ] ) ) {
+				return [];
+			}
+
 			return $preview_sites;
 		}
 

--- a/src/class-decoupled-preview-settings.php
+++ b/src/class-decoupled-preview-settings.php
@@ -589,11 +589,24 @@ if ( ! class_exists( __NAMESPACE__ . '\\Decoupled_Preview_Settings' ) ) {
 		/**
 		 * Delete preview site.
 		 *
+		 * Wraps around remove_site_from_list and actually updates the option.
+		 *
 		 * @param int|null $site_id (Optional) site id.
 		 *
 		 * @return void
 		 */
 		public function delete_preview_site( int $site_id = null ) {
+			update_option( 'preview_sites', $this->remove_site_from_list( $site_id ) );
+		}
+
+		/**
+		 * Handles the logic for removing a site from a saved list of preview sites.
+		 *
+		 * @param int|null $site_id (Optional) site id.
+		 *
+		 * @return array
+		 */
+		public function remove_site_from_list( int $site_id = null ) : array {
 			$site = $this->get_preview_site( $site_id );
 			$sites = get_option( 'preview_sites' );
 			$preview_sites = $sites['preview'];
@@ -628,7 +641,7 @@ if ( ! class_exists( __NAMESPACE__ . '\\Decoupled_Preview_Settings' ) ) {
 			unset( $sites['preview'] );
 			sort( $preview_sites );
 			$sites['preview'] = $preview_sites;
-			update_option( 'preview_sites', $sites );
+			return $sites;
 		}
 
 		/**
@@ -639,7 +652,7 @@ if ( ! class_exists( __NAMESPACE__ . '\\Decoupled_Preview_Settings' ) ) {
 		 *
 		 * @return array The updated array of preview sites.
 		 */
-		private function filter_preview_sites( array $preview_sites ) : array {
+		public function filter_preview_sites( array $preview_sites ) : array {
 			if ( count( $preview_sites ) < 1 ) {
 				return $preview_sites;
 			}

--- a/src/class-decoupled-preview-settings.php
+++ b/src/class-decoupled-preview-settings.php
@@ -350,6 +350,16 @@ if ( ! class_exists( __NAMESPACE__ . '\\Decoupled_Preview_Settings' ) ) {
 		 * @return array
 		 */
 		public function get_allowed_post_types() : array {
+			/**
+			 * Allow the allowable post types to be filtered.
+			 *
+			 * Usage:
+			 * add_filter( 'pantheon.dp.allowed_post_types', function( $allowed_types ) {
+			 *   $allowed_types[] = 'my_custom_post_type';
+			 *  return $allowed_types;
+			 * } );
+			 */
+			return apply_filters( 'pantheon.dp.allowed_post_types', [ 'post', 'page' ] );
 		}
 
 		/**

--- a/src/class-decoupled-preview-settings.php
+++ b/src/class-decoupled-preview-settings.php
@@ -349,8 +349,7 @@ if ( ! class_exists( __NAMESPACE__ . '\\Decoupled_Preview_Settings' ) ) {
 		 *
 		 * @return array
 		 */
-		private function get_allowed_post_types() : array {
-			return [ 'post', 'page' ];
+		public function get_allowed_post_types() : array {
 		}
 
 		/**
@@ -363,7 +362,7 @@ if ( ! class_exists( __NAMESPACE__ . '\\Decoupled_Preview_Settings' ) ) {
 		 *
 		 * @return string
 		 */
-		private function sanitize_preview_type( string $type ) : string {
+		public function sanitize_preview_type( string $type ) : string {
 			/**
 			 * Allow the allowable preview types to be filtered.
 			 *
@@ -398,7 +397,7 @@ if ( ! class_exists( __NAMESPACE__ . '\\Decoupled_Preview_Settings' ) ) {
 		 *
 		 * @return int
 		 */
-		private function validate_preview_id( int $edit_id, $options = [] ) : int {
+		public function validate_preview_id( int $edit_id, $options = [] ) : int {
 			if ( empty( $options ) ) {
 				$options = get_option( 'preview_sites' );
 			}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,3 +22,40 @@ function _manually_load_plugin() {
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 require $_tests_dir . '/includes/bootstrap.php';
+
+function _install_sites() {
+	$new_sites = [ 'preview' => _get_test_sites() ];
+	add_option( 'preview_sites', $new_sites );
+}
+
+function _remove_sites() {
+	delete_option( 'preview_sites' );
+}
+
+function _get_test_sites() : array {
+	return [
+		1 => [
+			'label' => 'Example NextJS Preview', 'wp-decoupled-preview',
+			'url' => 'https://example.com/api/preview',
+			'secret_string' => 'secret',
+			'preview_type' => 'Next.js',
+			'id' => 1,
+		],
+		2 => [
+			'label' => 'Test Site',
+			'url' => 'https://test-site.pantheonsite.io',
+			'secret_string' => 'test',
+			'preview_type' => 'Next.js',
+			'content_type' => [ 'post' ],
+			'id' => 2,
+		],
+		3 => [
+			'label' => 'Test Site 2',
+			'url' => 'https://test-site-2.pantheonsite.io',
+			'secret_string' => 'test',
+			'preview_type' => 'Next.js',
+			'content_type' => [ 'page' ],
+			'id' => 3,
+		],
+	];
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -35,7 +35,7 @@ function _remove_sites() {
 function _get_test_sites() : array {
 	return [
 		1 => [
-			'label' => 'Example NextJS Preview', 'wp-decoupled-preview',
+			'label' => 'Example NextJS Preview',
 			'url' => 'https://example.com/api/preview',
 			'secret_string' => 'secret',
 			'preview_type' => 'Next.js',

--- a/tests/test-decoupled-preview-settings.php
+++ b/tests/test-decoupled-preview-settings.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Test the Decoupled Preview Settings.
+ *
+ * @package Decoupled_Preview
+ */
+
+namespace Pantheon\DecoupledPreview;
+
+use WP_UnitTestCase;
+
+/**
+ * Main test suite.
+ */
+class Test_Settings extends WP_UnitTestCase {
+	public $settings = false;
+
+	public function setUp() : void {
+		parent::setUp();
+		require_once __DIR__ . '/../src/class-list-table.php';
+		_install_sites();
+		$this->settings = new Decoupled_Preview_Settings();
+	}
+
+	public function tearDown() : void {
+		parent::tearDown();
+		_remove_sites();
+		$this->settings = false;
+	}
+
+	public function test_get_allowed_post_types() : void {
+		$allowed_post_types = $this->settings->get_allowed_post_types();
+		$this->assertNotEmpty( $allowed_post_types );
+		$this->assertContains( 'post', $allowed_post_types );
+		$this->assertContains( 'page', $allowed_post_types );
+	}
+}

--- a/tests/test-decoupled-preview-settings.php
+++ b/tests/test-decoupled-preview-settings.php
@@ -47,7 +47,7 @@ class Test_Settings extends WP_UnitTestCase {
 		$this->assertContains( 'foo', $this->settings->get_allowed_post_types() );
 
 		// Override the default post types and test that the allowed post types are what we expect.
-		add_filter( 'pantheon.dp.allowed_post_types', function( $allowed_types ) {
+		add_filter( 'pantheon.dp.allowed_post_types', function() {
 			return [ 'bar', 'baz' ];
 		} );
 		$allowed_post_types = $this->settings->get_allowed_post_types();

--- a/tests/test-decoupled-preview-settings.php
+++ b/tests/test-decoupled-preview-settings.php
@@ -97,6 +97,20 @@ class Test_Settings extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the get_preview_site function.
+	 *
+	 * @dataProvider provider_preview_site
+	 *
+	 * @param array $expected The expected result.
+	 * @param int   $input    The input to test.
+	 *
+	 * @return void
+	 */
+	public function test_get_preview_site( $expected, $input ) : void {
+		$this->assertEquals( $expected, $this->settings->get_preview_site( $input ) );
+	}
+
+	/**
 	 * Data provider for test_validate_preview_id.
 	 *
 	 * @return array
@@ -109,6 +123,28 @@ class Test_Settings extends WP_UnitTestCase {
 			[ -1, 4 ],
 			[ 4, 4 ],
 			[ 35, 35 ],
+		];
+	}
+
+	public function provider_preview_site() : array {
+		$sites = _get_test_sites();
+		return [
+			[
+				'expected' => $sites[1],
+				'input' => 1,
+			],
+			[
+				'expected' => $sites[2],
+				'input' => 2,
+			],
+			[
+				'expected' => $sites[3],
+				'input' => 3,
+			],
+			[
+				'expected' => [],
+				'input' => 4,
+			],
 		];
 	}
 }

--- a/tests/test-decoupled-preview-settings.php
+++ b/tests/test-decoupled-preview-settings.php
@@ -28,10 +28,32 @@ class Test_Settings extends WP_UnitTestCase {
 		$this->settings = false;
 	}
 
+	/**
+	 * Test that the allowed post types are the expected values.
+	 *
+	 * @return void
+	 */
 	public function test_get_allowed_post_types() : void {
 		$allowed_post_types = $this->settings->get_allowed_post_types();
 		$this->assertNotEmpty( $allowed_post_types );
 		$this->assertContains( 'post', $allowed_post_types );
 		$this->assertContains( 'page', $allowed_post_types );
+
+		// Add a custom post type and test that it's in the list.
+		add_filter( 'pantheon.dp.allowed_post_types', function( $allowed_types ) {
+			$allowed_types[] = 'foo';
+			return $allowed_types;
+		} );
+		$this->assertContains( 'foo', $this->settings->get_allowed_post_types() );
+
+		// Override the default post types and test that the allowed post types are what we expect.
+		add_filter( 'pantheon.dp.allowed_post_types', function( $allowed_types ) {
+			return [ 'bar', 'baz' ];
+		} );
+		$allowed_post_types = $this->settings->get_allowed_post_types();
+		$this->assertNotContains( 'post', $allowed_post_types );
+		$this->assertNotContains( 'page', $allowed_post_types );
+		$this->assertContains( 'bar', $allowed_post_types );
+		$this->assertContains( 'baz', $allowed_post_types );
 	}
 }

--- a/tests/test-decoupled-preview-settings.php
+++ b/tests/test-decoupled-preview-settings.php
@@ -111,6 +111,26 @@ class Test_Settings extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the remove_site_from_list function.
+	 *
+	 * @covers Pantheon\DecoupledPreview\Decoupled_Preview_Settings::filter_preview_sites
+	 *
+	 * @return void
+	 */
+	public function test_remove_site_from_list() : void {
+		// Get the sites before so we can count them.
+		$sites_before = get_option( 'preview_sites' );
+		$sites_before_count = count( $sites_before['preview'] );
+
+		// Remove a site.
+		$sites_after = $this->settings->remove_site_from_list( 1 );
+		$sites_after_count = count( $sites_after['preview'] ) ;
+
+		// Make sure the count is one less.
+		$this->assertEquals( $sites_before_count - 1, $sites_after_count );
+	}
+
+	/**
 	 * Data provider for test_validate_preview_id.
 	 *
 	 * @return array

--- a/tests/test-decoupled-preview-settings.php
+++ b/tests/test-decoupled-preview-settings.php
@@ -87,6 +87,9 @@ class Test_Settings extends WP_UnitTestCase {
 	 *
 	 * @dataProvider provider_preview_id
 	 *
+	 * @param int $expected The expected result.
+	 * @param int $input    The input to test.
+	 *
 	 * @return void
 	 */
 	public function test_validate_preview_id( $input, $expected ) : void {

--- a/tests/test-decoupled-preview-settings.php
+++ b/tests/test-decoupled-preview-settings.php
@@ -56,4 +56,28 @@ class Test_Settings extends WP_UnitTestCase {
 		$this->assertContains( 'bar', $allowed_post_types );
 		$this->assertContains( 'baz', $allowed_post_types );
 	}
+
+	/**
+	 * Test that the allowed preview types are the expected values.
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_preview_type() : void {
+		$this->assertEquals( 'Next.js', $this->settings->sanitize_preview_type( 'Next.js' ) );
+		$this->assertNotEquals( 'Next.js', $this->settings->sanitize_preview_type( 'next.js' ) );
+
+		// Add a custom preview type and test that it's in the list.
+		add_filter( 'pantheon.dp.allowed_preview_types', function( $preview_types ) {
+			$preview_types[] = 'foo';
+			return $preview_types;
+		} );
+		$this->assertEquals( 'foo', $this->settings->sanitize_preview_type( 'foo' ) );
+
+		// Override the default preview types and test that the allowed preview types are what we expect.
+		add_filter( 'pantheon.dp.allowed_preview_types', function() {
+			return [ 'Gatsby' ];
+		} );
+		$this->assertEquals( 'Gatsby', $this->settings->sanitize_preview_type( 'Gatsby' ) );
+		$this->assertNotEquals( 'Next.js', $this->settings->sanitize_preview_type( 'Next.js' ) );
+	}
 }

--- a/tests/test-decoupled-preview-settings.php
+++ b/tests/test-decoupled-preview-settings.php
@@ -81,4 +81,31 @@ class Test_Settings extends WP_UnitTestCase {
 		$this->assertEquals( 'Gatsby', $this->settings->sanitize_preview_type( 'Gatsby' ) );
 		$this->assertNotEquals( 'Next.js', $this->settings->sanitize_preview_type( 'Next.js' ) );
 	}
+
+	/**
+	 * Test the preview ID validation.
+	 *
+	 * @dataProvider provider_preview_id
+	 *
+	 * @return void
+	 */
+	public function test_validate_preview_id( $input, $expected ) : void {
+		$this->assertEquals( $expected, $this->settings->validate_preview_id( $input ) );
+	}
+
+	/**
+	 * Data provider for test_validate_preview_id.
+	 *
+	 * @return array
+	 */
+	public function provider_preview_id() : array {
+		return [
+			[ 1, 1 ],
+			[ '1', 1 ],
+			[ 0, 4 ],
+			[ -1, 4 ],
+			[ 4, 4 ],
+			[ 35, 35 ],
+		];
+	}
 }

--- a/tests/test-decoupled-preview-settings.php
+++ b/tests/test-decoupled-preview-settings.php
@@ -65,6 +65,7 @@ class Test_Settings extends WP_UnitTestCase {
 	public function test_sanitize_preview_type() : void {
 		$this->assertEquals( 'Next.js', $this->settings->sanitize_preview_type( 'Next.js' ) );
 		$this->assertNotEquals( 'Next.js', $this->settings->sanitize_preview_type( 'next.js' ) );
+		$this->assertEquals( '', $this->settings->sanitize_preview_type( 'foo' ) );
 
 		// Add a custom preview type and test that it's in the list.
 		add_filter( 'pantheon.dp.allowed_preview_types', function( $preview_types ) {

--- a/tests/test-decoupled-preview-settings.php
+++ b/tests/test-decoupled-preview-settings.php
@@ -131,6 +131,33 @@ class Test_Settings extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the get_enabled_site_by_post_type function.
+	 *
+	 * @dataProvider provider_sites_by_post_type
+	 *
+	 * @param string $post_type The post type to test.
+	 * @param array  $expected  The expected result.
+	 *
+	 * @return void
+	 */
+	public function test_get_enabled_site_by_post_type( $post_type, $expected ) : void {
+		$sites = $this->settings->get_enabled_site_by_post_type( $post_type );
+
+		// Make sure the count is the same.
+		$this->assertEquals( count( $expected ), count( $sites ) );
+		foreach ( $sites as $site ) {
+			if ( isset( $site['content_type'] ) ) {
+				// If the site has a content type, make sure it's the one we expect. No value here means all post types are allowed.
+				$this->assertContains( $post_type, $site['content_type'] );
+			}
+
+			// Pluck the IDs from the expected array and make sure the current site is in the list.
+			$ids = wp_list_pluck( $expected, 'id' );
+			$this->assertContains( $site['id'], $ids );
+		}
+	}
+
+	/**
 	 * Data provider for test_validate_preview_id.
 	 *
 	 * @return array
@@ -146,6 +173,11 @@ class Test_Settings extends WP_UnitTestCase {
 		];
 	}
 
+	/**
+	 * Data provider for test_get_preview_site.
+	 *
+	 * @return array
+	 */
 	public function provider_preview_site() : array {
 		$sites = _get_test_sites();
 		return [
@@ -164,6 +196,56 @@ class Test_Settings extends WP_UnitTestCase {
 			[
 				'expected' => [],
 				'input' => 4,
+			],
+		];
+	}
+
+	/**
+	 * Data provider for test_get_enabled_site_by_post_type.
+	 *
+	 * @return array
+	 */
+	public function provider_sites_by_post_type() : array {
+		return [
+			[
+				'post_type' => 'post',
+				'expected' => [
+					[
+						'label' => 'Example NextJS Preview',
+						'url' => 'https://example.com/api/preview',
+						'secret_string' => 'secret',
+						'preview_type' => 'Next.js',
+						'id' => 1,
+					],
+					[
+						'label' => 'Test Site',
+						'url' => 'https://test-site.pantheonsite.io',
+						'secret_string' => 'test',
+						'preview_type' => 'Next.js',
+						'content_type' => [ 'post' ],
+						'id' => 2,
+					],
+				],
+			],
+			[
+				'post_type' => 'page',
+				'expected' => [
+					[
+						'label' => 'Example NextJS Preview',
+						'url' => 'https://example.com/api/preview',
+						'secret_string' => 'secret',
+						'preview_type' => 'Next.js',
+						'id' => 1,
+					],
+					[
+						'label' => 'Test Site 2',
+						'url' => 'https://test-site-2.pantheonsite.io',
+						'secret_string' => 'test',
+						'preview_type' => 'Next.js',
+						'content_type' => [ 'page' ],
+						'id' => 3,
+					],
+				],
 			],
 		];
 	}

--- a/tests/test-list-table.php
+++ b/tests/test-list-table.php
@@ -72,6 +72,9 @@ class Test_List_Table extends WP_UnitTestCase {
 	 *
 	 * @dataProvider provider_column_default
 	 *
+	 * @param array $expected_result The expected result.
+	 * @param array $input The input.
+	 *
 	 * @return void
 	 */
 	public function test_column_default( $expected_result, $input ) : void {

--- a/tests/test-list-table.php
+++ b/tests/test-list-table.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Test the Decoupled Preview list table.
+ *
+ * @package Decoupled_Preview
+ */
+
+namespace Pantheon\DecoupledPreview;
+
+use ReflectionMethod;
+use WP_UnitTestCase;
+
+class Test_List_Table extends WP_UnitTestCase {
+	public $list_table = false;
+
+	public function setUp() : void {
+		parent::setUp();
+		require_once __DIR__ . '/../src/class-list-table.php';
+		_install_sites();
+		$this->list_table = new List_Table();
+	}
+
+	public function tearDown() : void {
+		parent::tearDown();
+		_remove_sites();
+		$this->list_table = false;
+	}
+
+	/**
+	 * Test that the list table exists and has items.
+	 *
+	 * Sites are created via _install_sites() in tests/bootstrap.php.
+	 *
+	 * @return void
+	 */
+	public function test_prepare_items() : void {
+		$this->list_table->prepare_items();
+		$items = $this->list_table->items;
+		$this->assertNotEmpty( $items );
+		$this->assertEquals( 3, count( $items ) );
+	}
+
+	/**
+	 * Test that the list table has the expected sortable columns.
+	 *
+	 * @return void
+	 */
+	public function test_get_sortable() : void {
+		$sortable = $this->list_table->get_sortable_columns();
+		$this->assertNotEmpty( $sortable );
+		$this->assertArrayHasKey( 'label', $sortable );
+		$this->assertArrayHasKey( 'preview_type', $sortable );
+		$this->assertArrayHasKey( 'content_type', $sortable );
+	}
+
+	/**
+	 * Test that the no items message is the expected value. This test is
+	 * pretty trivial but it's here to demonstrate how to test a method that
+	 * outputs HTML.
+	 *
+	 * @return void
+	 */
+	public function test_no_items() : void {
+		ob_start();
+		$this->list_table->no_items();
+		$no_items = ob_get_clean();
+		$this->assertEquals( 'No preview sites configured.', $no_items );
+	}
+
+}

--- a/tests/test-list-table.php
+++ b/tests/test-list-table.php
@@ -67,4 +67,57 @@ class Test_List_Table extends WP_UnitTestCase {
 		$this->assertEquals( 'No preview sites configured.', $no_items );
 	}
 
+	/**
+	 * Test list table columns output.
+	 *
+	 * @dataProvider provider_column_default
+	 *
+	 * @return void
+	 */
+	public function test_column_default( $expected_result, $input ) : void {
+		$columns = [ 'label', 'url', 'preview_type', 'content_type' ];
+
+		foreach ( $columns as $column ) {
+			$this->assertEquals( $this->list_table->column_default( $input, $column ), $expected_result[ $column ] );
+			// var_dump( $this->list_table->column_default( $input, $column ), $expected_result );
+		}
+	}
+
+	/**
+	 * Data provider for test_column_default().
+	 *
+	 * @return array
+	 */
+	public function provider_column_default() : array {
+		$data = _get_test_sites();
+		return [
+			[
+				'expected_result' => [
+					'label' => 'Example NextJS Preview',
+					'url' => 'https://example.com/api/preview',
+					'preview_type' => 'Next.js',
+					'content_type' => 'Post, Page',
+				],
+				'input' => $data[1],
+			],
+			[
+				'expected_result' => [
+					'label' => 'Test Site',
+					'url' => 'https://test-site.pantheonsite.io',
+					'preview_type' => 'Next.js',
+					'content_type' => 'Post',
+				],
+				'input' => $data[2],
+			],
+			[
+				'expected_result' => [
+					'label' => 'Test Site 2',
+					'url' => 'https://test-site-2.pantheonsite.io',
+					'preview_type' => 'Next.js',
+					'content_type' => 'Page',
+				],
+				'input' => $data[3],
+			],
+		];
+	}
 }

--- a/tests/test-list-table.php
+++ b/tests/test-list-table.php
@@ -75,11 +75,10 @@ class Test_List_Table extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_column_default( $expected_result, $input ) : void {
-		$columns = [ 'label', 'url', 'preview_type', 'content_type' ];
+		$columns = [ 'label', 'url', 'preview_type', 'content_type', '' ];
 
 		foreach ( $columns as $column ) {
 			$this->assertEquals( $this->list_table->column_default( $input, $column ), $expected_result[ $column ] );
-			// var_dump( $this->list_table->column_default( $input, $column ), $expected_result );
 		}
 	}
 
@@ -97,6 +96,7 @@ class Test_List_Table extends WP_UnitTestCase {
 					'url' => 'https://example.com/api/preview',
 					'preview_type' => 'Next.js',
 					'content_type' => 'Post, Page',
+					'' => '',
 				],
 				'input' => $data[1],
 			],
@@ -106,6 +106,7 @@ class Test_List_Table extends WP_UnitTestCase {
 					'url' => 'https://test-site.pantheonsite.io',
 					'preview_type' => 'Next.js',
 					'content_type' => 'Post',
+					'' => '',
 				],
 				'input' => $data[2],
 			],
@@ -115,6 +116,7 @@ class Test_List_Table extends WP_UnitTestCase {
 					'url' => 'https://test-site-2.pantheonsite.io',
 					'preview_type' => 'Next.js',
 					'content_type' => 'Page',
+					'' => '',
 				],
 				'input' => $data[3],
 			],

--- a/tests/test-main.php
+++ b/tests/test-main.php
@@ -15,16 +15,60 @@ use WP_UnitTestCase;
 class Test_Main extends WP_UnitTestCase {
 	/**
 	 * Test that the plugin is loaded.
+	 *
+	 * @return void
 	 */
-	public function test_plugin_loaded() {
+	public function test_plugin_loaded() : void {
 		$this->assertTrue( defined( 'WP_DECOUPLED_PREVIEW_ENABLED' ) );
 		$this->assertTrue( WP_DECOUPLED_PREVIEW_ENABLED );
 	}
 
 	/**
 	 * Test that the plugin class exists.
+	 *
+	 * @return void
 	 */
-	public function test_class_exists() {
+	public function test_class_exists() : void {
 		$this->assertTrue( class_exists( __NAMESPACE__ . '\\Decoupled_Preview_Settings' ) );
+	}
+
+	/**
+	 * Test the set_default_options() and delete_default_options() functions.
+	 *
+	 * @covers \Pantheon\DecoupledPreview\set_default_options()
+	 * @covers \Pantheon\DecoupledPreview\delete_default_options()
+	 *
+	 * @return void
+	 */
+	public function test_default_options() : void {
+		// Set the default options.
+		set_default_options();
+		$options = get_option( 'preview_sites' );
+		$this->assertNotEmpty( $options );
+
+		// Ensure that the transient was set.
+		$transient = get_transient( 'example_preview_password' );
+		$this->assertNotEmpty( $transient );
+
+		// Ensure that the options were set.
+		$this->assertNotEmpty( $options );
+		$this->assertArrayHasKey( 'preview', $options );
+		$this->assertArrayHasKey( 'label', $options['preview'][1] );
+		$this->assertEquals( 'Example NextJS Preview', $options['preview'][1]['label'] );
+		$this->assertArrayHasKey( 'url', $options['preview'][1] );
+		$this->assertEquals( 'https://example.com/api/preview', $options['preview'][1]['url'] );
+		$this->assertArrayHasKey( 'secret_string', $options['preview'][1] );
+		$this->assertEquals( $transient, $options['preview'][1]['secret_string'] );
+		$this->assertArrayHasKey( 'preview_type', $options['preview'][1] );
+		$this->assertEquals( 'Next.js', $options['preview'][1]['preview_type'] );
+		$this->assertArrayHasKey( 'id', $options['preview'][1] );
+		$this->assertEquals( 1, $options['preview'][1]['id'] );
+
+		// Delete the options.
+		delete_default_options();
+		$options = get_option( 'preview_sites' );
+
+		// Ensure that the options were deleted.
+		$this->assertEmpty( $options );
 	}
 }

--- a/wp-decoupled-preview.php
+++ b/wp-decoupled-preview.php
@@ -137,7 +137,7 @@ function delete_default_options() {
  * @return void
  */
 function redirect_to_preview_site( $option_name ) {
-	if ( 'preview_sites' === $option_name ) {
+	if ( 'preview_sites' === $option_name && is_admin() ) {
 		echo '<script type="text/javascript">window.location = "options-general.php?page=preview_sites"</script>';
 		exit;
 	}

--- a/wp-decoupled-preview.php
+++ b/wp-decoupled-preview.php
@@ -77,7 +77,6 @@ function conditionally_enqueue_scripts() {
  * @return void
  */
 function set_default_options() {
-
 	$secret = wp_generate_password( 10, false );
 	set_transient( 'example_preview_password', $secret );
 


### PR DESCRIPTION
Forked from #16.

This adds more robust unit testing as well as some fixes related to them.
Updated the base branch to [`cmsp-206`](https://github.com/pantheon-systems/wp-decoupled-preview/tree/cmsp-206) since these fork from that and should merge into that if that is not merged first.

This PR also updates the README.md with notes about running lint checks and tests locally and adds relevant badges.