### PR TITLE
[CMSP-206] Audit the preview-template.php file

### DIFF
--- a/templates/preview-template.php
+++ b/templates/preview-template.php
@@ -36,8 +36,10 @@ $redirect = "{$preview_site['url']}?secret={$preview_site['secret_string']}&uri=
 	<script>
 		<?php
 		if ( $preview_site['url'] ) {
-			// Redirecting via JS because the page headers have already been set by
-			// the time we get into this template so PHP wont redirect.
+			/*
+			 * Redirecting via JS because the page headers have already been
+			 * set by the time we get into this template so PHP won't redirect.
+			 */
 			echo 'window.location.replace("' . esc_url_raw( $redirect ) . '");';
 		}
 		?>

--- a/templates/preview-template.php
+++ b/templates/preview-template.php
@@ -7,20 +7,20 @@
 
 namespace Pantheon\DecoupledPreview;
 
-$preview_id      = isset( $_GET['preview_id'] ) ? sanitize_text_field( wp_unslash( $_GET['preview_id'] ) ) : false;
+$preview_id = isset( $_GET['preview_id'] ) ? sanitize_text_field( wp_unslash( $_GET['preview_id'] ) ) : false;
 $preview_site_id = isset( $_GET['decoupled_preview_site'] ) ? sanitize_text_field( wp_unslash( $_GET['decoupled_preview_site'] ) ) : false;
-$nonce           = isset( $_GET['preview_nonce'] ) ? sanitize_text_field( wp_unslash( $_GET['preview_nonce'] ) ) : false;
+$nonce = isset( $_GET['preview_nonce'] ) ? sanitize_text_field( wp_unslash( $_GET['preview_nonce'] ) ) : false;
 
 if ( ! wp_verify_nonce( $nonce, 'post_preview_' . $preview_id ) ) {
 	wp_die( 'Unable to preview: invalid nonce' );
 }
 
-$preview_post      = get_post( $preview_id );
-$revision          = wp_get_post_autosave( $preview_id, get_current_user_id() );
+$preview_post = get_post( $preview_id );
+$revision = wp_get_post_autosave( $preview_id, get_current_user_id() );
 $preview_post_type = get_post_type( $preview_post );
 
 $preview_helper = new Decoupled_Preview_Settings();
-$preview_site   = $preview_helper->get_preview_site( $preview_site_id );
+$preview_site = $preview_helper->get_preview_site( $preview_site_id );
 
 $redirect = "{$preview_site['url']}?secret={$preview_site['secret_string']}&uri={$preview_post->post_name}&id={$revision->ID}&content_type={$preview_post_type}";
 ?>

--- a/templates/preview-template.php
+++ b/templates/preview-template.php
@@ -31,7 +31,7 @@ $redirect = "{$preview_site['url']}?secret={$preview_site['secret_string']}&uri=
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
-	<title>Decoupled Preview</title>
+	<title><?php esc_html_e( 'Decoupled Preview', 'wp-decoupled-preview' ); ?></title>
 
 	<script>
 		<?php
@@ -45,7 +45,7 @@ $redirect = "{$preview_site['url']}?secret={$preview_site['secret_string']}&uri=
 </head>
 
 <body>
-	<h1>Redirecting to preview site...</h1>
+	<h1><?php esc_html_e( 'Redirecting to preview site...', 'wp-decoupled-preview' ); ?></h1>
 </body>
 
 <?php wp_footer(); ?>


### PR DESCRIPTION
Not a lot here since we fixed the issue with the lack of namespacing, but our pairing session revealed that I hadn't even looked at this file. 😅 

The only changes here are relatively minor nits:

* don't worry about aligning variables. That's a rule that I've removed from our Pantheon WP Coding Standards as a flagging sniff and there are reasons...
* Multi-line comments should use `/*` comments rather than `//` -- this isn't enforced by our coding standards (but maybe it should be...)
* added i18n

That's it!