### PR TITLE
[CMSP-205] updates the plugin uri so it is not the same as the author uri

### DIFF
--- a/wp-decoupled-preview.php
+++ b/wp-decoupled-preview.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:     Pantheon Decoupled Preview
- * Plugin URI:      https://pantheon.io/
+ * Plugin URI:      https://github.com/pantheon-systems/wp-decoupled-preview
  * Description:     Preview WordPress content on Front-end sites including Next.js
  * Version:         1.0.0
  * Author:          Pantheon


### PR DESCRIPTION
Plugin auto-checker reported the following: 

> Error: Your plugin and author URIs are the same. Your plugin headers in the main plugin file headers have the same value for both the plugin and author URI (Uniform Resource Identifier). A plugin URI is a webpage that provides details about this specific plugin. An author URI is a webpage that provides information about the author of the plugin. Those two must be different. You are not required to provide both, so pick the one that best applies to your situation.

Updating the plugin uri so it is different than the author uri