### PR TITLE
create the wordpress_test database on wpunit install

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -15,13 +15,12 @@ jobs:
       - name: Setup MySQL
         run: |
           sudo /etc/init.d/mysql start
-          mysql -e 'CREATE DATABASE IF NOT EXISTS wordpress_test;' -uroot -proot
           mysql -e 'SHOW DATABASES;' -uroot -proot
       - name: Install WP Unit tests
         run: |
           php -v
           mysqladmin -V
-          bash .bin/install-wp-tests.sh wordpress_test ${{ secrets.DB_USER }} ${{ secrets.DB_PASSWORD }} localhost latest true
+          bash .bin/install-wp-tests.sh wordpress_test ${{ secrets.DB_USER }} ${{ secrets.DB_PASSWORD }} localhost latest
       - name: Run linter
         run: composer lint
       - name: Run tests


### PR DESCRIPTION
This fixes the failing test steps seen [here](https://github.com/pantheon-systems/wp-decoupled-preview/pull/28#event-9041544677). The syntax for skipping database creation is correct, in theory, but we don't actually need to create the `wordpress_test` database when setting up MySQL, we can just let the script do it, and that seems to resolve the issue.