### PR TITLE
sets the default branch for dependabot to `develop` instead of `main`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,5 @@ updates:
       interval: weekly
       timezone: America/Los_Angeles
       day: tuesday
-    target-branch: "main"
+    target-branch: "develop"
     open-pull-requests-limit: 99


### PR DESCRIPTION
Use `develop` instead of `main` so @jspellman814 doesn't have to do it manually. 😅