### PR TITLE
DB-6065: Unable to Preview post/pages while editing

### DIFF
--- a/templates/preview-template.php
+++ b/templates/preview-template.php
@@ -18,11 +18,13 @@ if ( ! wp_verify_nonce( $nonce, 'post_preview_' . $preview_id ) ) {
 $preview_post = get_post( $preview_id );
 $revision = wp_get_post_autosave( $preview_id, get_current_user_id() );
 $preview_post_type = get_post_type( $preview_post );
+// If the a revision exists, use that ID instead of the post ID.
+$id = $revision->ID ? $revision->ID : $preview_id;
 
 $preview_helper = new Decoupled_Preview_Settings();
 $preview_site = $preview_helper->get_preview_site( $preview_site_id );
 
-$redirect = "{$preview_site['url']}?secret={$preview_site['secret_string']}&uri={$preview_post->post_name}&id={$revision->ID}&content_type={$preview_post_type}";
+$redirect = "{$preview_site['url']}?secret={$preview_site['secret_string']}&uri={$preview_post->post_name}&id={$id}&content_type={$preview_post_type}";
 ?>
 
 <html lang="en">

--- a/templates/preview-template.php
+++ b/templates/preview-template.php
@@ -18,7 +18,7 @@ if ( ! wp_verify_nonce( $nonce, 'post_preview_' . $preview_id ) ) {
 $preview_post = get_post( $preview_id );
 $revision = wp_get_post_autosave( $preview_id, get_current_user_id() );
 $preview_post_type = get_post_type( $preview_post );
-// If the a revision exists, use that ID instead of the post ID.
+// If a revision exists, use that ID instead of the post ID.
 $id = $revision->ID ? $revision->ID : $preview_id;
 
 $preview_helper = new Decoupled_Preview_Settings();


### PR DESCRIPTION
In cases where a published post doesn't yet have a revision, no ID is being passed to the preview API route. This protects from that by passing the post ID if a revision ID doesn't exist. The post ID is valid for preview if no revisions exist.