### PR TITLE
DB-6162: Decoupled Preview Link not working in WordPress

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ NextJS sites using a similar approach.
 ## Known Issues
 
 - Currently this plugin does not support custom post types.
+- Currently this plugin does not support the classic editor.
 
 ## Linting and Testing
 

--- a/js/add-new-preview-btn.js
+++ b/js/add-new-preview-btn.js
@@ -31,7 +31,7 @@ window.addEventListener(
             previewSubmenu.classList.toggle( "hidden" );
             previewSubmenu.classList.toggle( "components-popover__content" );
             // Change the edit post side bar z-index.
-            document.querySelector( '.interface-interface-skeleton__sidebar' ).classList.toggle( 'interface-z-index-0' );
+            document.querySelector( '.interface-interface-skeleton__sidebar' ).style.zIndex = 0;
           }
         );
         clearInterval(checkPreviewInterval);

--- a/js/add-new-preview-btn.js
+++ b/js/add-new-preview-btn.js
@@ -13,7 +13,7 @@ window.addEventListener(
 
     // Ensure that block editor preview button exists, and if so, modify it.
     const checkPreview = () => {
-      const previewBlock    	  = document.querySelector( ".block-editor-post-preview__dropdown" );
+      const previewBlock = document.querySelector( ".block-editor-post-preview__dropdown" );
       const decoupledPreviewBtn = document.getElementById( 'wp-admin-bar-decoupled-preview' );
       // Remove the old Preview button.
       if (previewBlock) {

--- a/js/add-new-preview-btn.js
+++ b/js/add-new-preview-btn.js
@@ -9,25 +9,41 @@
 window.addEventListener(
 	"load",
 	() => {
-		const previewBlock    	  = document.querySelector( ".block-editor-post-preview__dropdown" );
-		const decoupledPreviewBtn = document.getElementById( 'wp-admin-bar-decoupled-preview' );
-		// Remove the old Preview button.
-		previewBlock.removeChild( previewBlock.querySelector( 'button' ) );
-		// Add Decoupled Preview Button into the same Preview continer.
-		previewBlock.appendChild( decoupledPreviewBtn );
-		// Hide submenu items by default.
-		const previewSubmenu = decoupledPreviewBtn.querySelector( ".ab-sub-wrapper" );
-		previewSubmenu.classList.add( "hidden" );
-		// Add event listener to toggle submenu items.
-		decoupledPreviewBtn.addEventListener(
-			"click",
-			(e) => {
-				wp.data.dispatch( 'core/editor' ).autosave();
-				previewSubmenu.classList.toggle( "hidden" );
-				previewSubmenu.classList.toggle( "components-popover__content" );
-				// Change the edit post side bar z-index.
-				document.querySelector( '.interface-interface-skeleton__sidebar' ).classList.toggle( 'interface-z-index-0' );
-			}
-		);
+    let editorChecks = 0;
+
+    // Ensure that block editor preview button exists, and if so, modify it.
+    const checkPreview = () => {
+      const previewBlock    	  = document.querySelector( ".block-editor-post-preview__dropdown" );
+      const decoupledPreviewBtn = document.getElementById( 'wp-admin-bar-decoupled-preview' );
+      // Remove the old Preview button.
+      if (previewBlock) {
+        previewBlock.removeChild( previewBlock.querySelector( 'button' ) );
+        // Add Decoupled Preview Button into the same Preview container.
+        previewBlock.appendChild( decoupledPreviewBtn );
+        // Hide submenu items by default.
+        const previewSubmenu = decoupledPreviewBtn.querySelector( ".ab-sub-wrapper" );
+        previewSubmenu.classList.add( "hidden" );
+        // Add event listener to toggle submenu items.
+        decoupledPreviewBtn.addEventListener(
+          "click",
+          (e) => {
+            wp.data.dispatch( 'core/editor' ).autosave();
+            previewSubmenu.classList.toggle( "hidden" );
+            previewSubmenu.classList.toggle( "components-popover__content" );
+            // Change the edit post side bar z-index.
+            document.querySelector( '.interface-interface-skeleton__sidebar' ).classList.toggle( 'interface-z-index-0' );
+          }
+        );
+        clearInterval(checkPreviewInterval);
+      }
+      // Limit the number of checks for the preview button.
+      else {
+        editorChecks++;
+        if (editorChecks > 24) {
+          clearInterval(checkPreviewInterval);
+        }
+      }
+    }
+    const checkPreviewInterval = setInterval(checkPreview, 200);
 	}
 );

--- a/readme.txt
+++ b/readme.txt
@@ -49,6 +49,10 @@ Additional information on configuring the plugin can be found in the configurati
 
 While we hope to expand in the future, the initial release of this plugin only supports NextJS. It was developed in support of [Pantheon's Next WordPress Starter](https://github.com/pantheon-systems/next-wordpress-starter), but can be applied to other NextJS sites using a similar approach.
 
+= Does this plugin support the classic editor? =
+
+This plugin currently only supports the block editor.
+
 == Changelog ==
 
 ** Latest **

--- a/wp-decoupled-preview.php
+++ b/wp-decoupled-preview.php
@@ -61,7 +61,7 @@ function conditionally_enqueue_scripts() {
 
 	if ( 'post.php' === $pagenow || 'post-new.php' === $pagenow ) {
 		add_action( 'admin_bar_menu', __NAMESPACE__ . '\\add_admin_decoupled_preview_link', 100 );
-		add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_scripts', 100 );
+		add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
 	}
 
 	// We're not processing this information at all so we can bypass the nonce here.


### PR DESCRIPTION
Refactored previous attempt at this - ended up requiring a little more than changing the js loading strategy.

* JS now polls for the existence of the preview button in the editor before attempting to modify it.
* Added minor styling fix to address z-index issues with sidebar panel.
* Clarified in readmes that this plugin currently only supports the block editor. (We'd need to make more changes than I had assumed in order to support the classic editor, so I'll log it as a feature and we can track demand.)