### PR TITLE
DB-6162: Decoupled Preview Link not working in WordPress (PR recreated on upstream)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ NextJS sites using a similar approach.
 ## Known Issues
 
 - Currently this plugin does not support custom post types.
+- Currently this plugin does not support the classic editor.
 
 ## Linting and Testing
 

--- a/composer.lock
+++ b/composer.lock
@@ -263,17 +263,13 @@
         {
             "name": "myclabs/deep-copy",
             "version": "1.11.1",
-            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
                 "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
                 "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
                 "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
                 "shasum": ""
@@ -314,7 +310,6 @@
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
                 "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
             },
             "funding": [
                 {
@@ -323,24 +318,19 @@
                 }
             ],
             "time": "2023-03-08T13:26:56+00:00"
-            "time": "2023-03-08T13:26:56+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.4",
-            "version": "v4.15.4",
+            "version": "v4.15.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290"
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290"
+                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/11e2663a5bc9db5d714eedb4277ee300403b4a9e",
+                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e",
                 "shasum": ""
             },
             "require": {
@@ -381,26 +371,20 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.4"
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.4"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.5"
             },
-            "time": "2023-03-05T19:49:14+00:00"
-            "time": "2023-03-05T19:49:14+00:00"
+            "time": "2023-05-19T20:20:00+00:00"
         },
         {
             "name": "pantheon-systems/pantheon-wp-coding-standards",
-            "version": "1.0.1",
             "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards.git",
                 "reference": "1e8fb654d52b9274f548c46f89d98f4913307fdf"
-                "reference": "1e8fb654d52b9274f548c46f89d98f4913307fdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pantheon-systems/Pantheon-WP-Coding-Standards/zipball/1e8fb654d52b9274f548c46f89d98f4913307fdf",
-                "reference": "1e8fb654d52b9274f548c46f89d98f4913307fdf",
                 "url": "https://api.github.com/repos/pantheon-systems/Pantheon-WP-Coding-Standards/zipball/1e8fb654d52b9274f548c46f89d98f4913307fdf",
                 "reference": "1e8fb654d52b9274f548c46f89d98f4913307fdf",
                 "shasum": ""
@@ -430,9 +414,7 @@
             "support": {
                 "issues": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/issues",
                 "source": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/tree/1.0.1"
-                "source": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/tree/1.0.1"
             },
-            "time": "2023-04-14T16:54:02+00:00"
             "time": "2023-04-14T16:54:02+00:00"
         },
         {
@@ -723,17 +705,13 @@
         {
             "name": "phpstan/phpdoc-parser",
             "version": "1.20.4",
-            "version": "1.20.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
                 "reference": "7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd"
-                "reference": "7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd",
-                "reference": "7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd",
                 "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd",
                 "reference": "7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd",
                 "shasum": ""
@@ -766,25 +744,19 @@
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/1.20.4"
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.20.4"
             },
-            "time": "2023-05-02T09:19:37+00:00"
             "time": "2023-05-02T09:19:37+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
             "version": "9.2.26",
-            "version": "9.2.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
                 "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
                 "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
                 "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
                 "shasum": ""
@@ -793,7 +765,6 @@
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.15",
                 "nikic/php-parser": "^4.15",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
@@ -809,8 +780,6 @@
                 "phpunit/phpunit": "^9.3"
             },
             "suggest": {
-                "ext-pcov": "PHP extension that provides line coverage",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
                 "ext-pcov": "PHP extension that provides line coverage",
                 "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
@@ -846,7 +815,6 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
             },
             "funding": [
                 {
@@ -854,7 +822,6 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-06T12:58:08+00:00"
             "time": "2023-03-06T12:58:08+00:00"
         },
         {
@@ -1100,16 +1067,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.8",
+            "version": "9.6.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e"
+                "reference": "a9aceaf20a682aeacf28d582654a1670d8826778"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/17d621b3aff84d0c8b62539e269e87d8d5baa76e",
-                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a9aceaf20a682aeacf28d582654a1670d8826778",
+                "reference": "a9aceaf20a682aeacf28d582654a1670d8826778",
                 "shasum": ""
             },
             "require": {
@@ -1142,8 +1109,6 @@
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
                 "ext-soap": "To be able to generate mocks based on WSDL files",
                 "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
@@ -1185,7 +1150,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.8"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.9"
             },
             "funding": [
                 {
@@ -1201,7 +1166,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-11T05:14:45+00:00"
+            "time": "2023-06-11T06:13:56+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2170,17 +2135,13 @@
         {
             "name": "sirbrillig/phpcs-variable-analysis",
             "version": "v2.11.16",
-            "version": "v2.11.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
                 "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88"
-                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/dc5582dc5a93a235557af73e523c389aac9a8e88",
-                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88",
                 "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/dc5582dc5a93a235557af73e523c389aac9a8e88",
                 "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88",
                 "shasum": ""
@@ -2228,7 +2189,6 @@
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
             "time": "2023-03-31T16:46:32+00:00"
-            "time": "2023-03-31T16:46:32+00:00"
         },
         {
             "name": "slevomat/coding-standard",
@@ -2247,7 +2207,6 @@
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpdoc-parser": ">=1.20.0 <1.21.0",
                 "phpstan/phpdoc-parser": ">=1.20.0 <1.21.0",
                 "squizlabs/php_codesniffer": "^3.7.1"
             },
@@ -2268,7 +2227,6 @@
             },
             "autoload": {
                 "psr-4": {
-                    "SlevomatCodingStandard\\": "SlevomatCodingStandard/"
                     "SlevomatCodingStandard\\": "SlevomatCodingStandard/"
                 }
             },
@@ -2358,17 +2316,13 @@
         {
             "name": "squizlabs/php_codesniffer",
             "version": "3.7.2",
-            "version": "3.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
                 "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
@@ -2408,15 +2362,12 @@
                 "phpcs",
                 "standards",
                 "static analysis"
-                "standards",
-                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2023-02-22T23:07:41+00:00"
             "time": "2023-02-22T23:07:41+00:00"
         },
         {
@@ -2523,17 +2474,13 @@
         {
             "name": "yoast/phpunit-polyfills",
             "version": "1.0.5",
-            "version": "1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
                 "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171"
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
                 "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
                 "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
                 "shasum": ""
@@ -2544,12 +2491,10 @@
             },
             "require-dev": {
                 "yoast/yoastcs": "^2.3.0"
-                "yoast/yoastcs": "^2.3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.x-dev"
                     "dev-main": "2.x-dev"
                 }
             },
@@ -2584,7 +2529,6 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2023-03-30T23:39:05+00:00"
             "time": "2023-03-30T23:39:05+00:00"
         }
     ],

--- a/js/add-new-preview-btn.js
+++ b/js/add-new-preview-btn.js
@@ -31,7 +31,7 @@ window.addEventListener(
             previewSubmenu.classList.toggle( "hidden" );
             previewSubmenu.classList.toggle( "components-popover__content" );
             // Change the edit post side bar z-index.
-            document.querySelector( '.interface-interface-skeleton__sidebar' ).classList.toggle( 'interface-z-index-0' );
+            document.querySelector( '.interface-interface-skeleton__sidebar' ).style.zIndex = 0;
           }
         );
         clearInterval(checkPreviewInterval);

--- a/js/add-new-preview-btn.js
+++ b/js/add-new-preview-btn.js
@@ -9,25 +9,41 @@
 window.addEventListener(
 	"load",
 	() => {
-		const previewBlock    	  = document.querySelector( ".block-editor-post-preview__dropdown" );
-		const decoupledPreviewBtn = document.getElementById( 'wp-admin-bar-decoupled-preview' );
-		// Remove the old Preview button.
-		previewBlock.removeChild( previewBlock.querySelector( 'button' ) );
-		// Add Decoupled Preview Button into the same Preview continer.
-		previewBlock.appendChild( decoupledPreviewBtn );
-		// Hide submenu items by default.
-		const previewSubmenu = decoupledPreviewBtn.querySelector( ".ab-sub-wrapper" );
-		previewSubmenu.classList.add( "hidden" );
-		// Add event listener to toggle submenu items.
-		decoupledPreviewBtn.addEventListener(
-			"click",
-			(e) => {
-				wp.data.dispatch( 'core/editor' ).autosave();
-				previewSubmenu.classList.toggle( "hidden" );
-				previewSubmenu.classList.toggle( "components-popover__content" );
-				// Change the edit post side bar z-index.
-				document.querySelector( '.interface-interface-skeleton__sidebar' ).classList.toggle( 'interface-z-index-0' );
-			}
-		);
+    let editorChecks = 0;
+
+    // Ensure that block editor preview button exists, and if so, modify it.
+    const checkPreview = () => {
+      const previewBlock    	  = document.querySelector( ".block-editor-post-preview__dropdown" );
+      const decoupledPreviewBtn = document.getElementById( 'wp-admin-bar-decoupled-preview' );
+      // Remove the old Preview button.
+      if (previewBlock) {
+        previewBlock.removeChild( previewBlock.querySelector( 'button' ) );
+        // Add Decoupled Preview Button into the same Preview container.
+        previewBlock.appendChild( decoupledPreviewBtn );
+        // Hide submenu items by default.
+        const previewSubmenu = decoupledPreviewBtn.querySelector( ".ab-sub-wrapper" );
+        previewSubmenu.classList.add( "hidden" );
+        // Add event listener to toggle submenu items.
+        decoupledPreviewBtn.addEventListener(
+          "click",
+          (e) => {
+            wp.data.dispatch( 'core/editor' ).autosave();
+            previewSubmenu.classList.toggle( "hidden" );
+            previewSubmenu.classList.toggle( "components-popover__content" );
+            // Change the edit post side bar z-index.
+            document.querySelector( '.interface-interface-skeleton__sidebar' ).classList.toggle( 'interface-z-index-0' );
+          }
+        );
+        clearInterval(checkPreviewInterval);
+      }
+      // Limit the number of checks for the preview button.
+      else {
+        editorChecks++;
+        if (editorChecks > 24) {
+          clearInterval(checkPreviewInterval);
+        }
+      }
+    }
+    const checkPreviewInterval = setInterval(checkPreview, 200);
 	}
 );

--- a/readme.txt
+++ b/readme.txt
@@ -49,6 +49,10 @@ Additional information on configuring the plugin can be found in the configurati
 
 While we hope to expand in the future, the initial release of this plugin only supports NextJS. It was developed in support of [Pantheon's Next WordPress Starter](https://github.com/pantheon-systems/next-wordpress-starter), but can be applied to other NextJS sites using a similar approach.
 
+= Does this plugin support the classic editor? =
+
+This plugin currently only supports the block editor.
+
 == Changelog ==
 
 ** Latest **

--- a/templates/preview-template.php
+++ b/templates/preview-template.php
@@ -19,12 +19,12 @@ $preview_post = get_post( $preview_id );
 $revision = wp_get_post_autosave( $preview_id, get_current_user_id() );
 $preview_post_type = get_post_type( $preview_post );
 // If a revision exists, use that ID instead of the post ID.
-$id = $revision->ID ? $revision->ID : $preview_id;
+$active_id = $revision->ID ? $revision->ID : $preview_id;
 
 $preview_helper = new Decoupled_Preview_Settings();
 $preview_site = $preview_helper->get_preview_site( $preview_site_id );
 
-$redirect = "{$preview_site['url']}?secret={$preview_site['secret_string']}&uri={$preview_post->post_name}&id={$id}&content_type={$preview_post_type}";
+$redirect = "{$preview_site['url']}?secret={$preview_site['secret_string']}&uri={$preview_post->post_name}&id={$active_id}&content_type={$preview_post_type}";
 ?>
 
 <html lang="en">

--- a/wp-decoupled-preview.php
+++ b/wp-decoupled-preview.php
@@ -61,7 +61,7 @@ function conditionally_enqueue_scripts() {
 
 	if ( 'post.php' === $pagenow || 'post-new.php' === $pagenow ) {
 		add_action( 'admin_bar_menu', __NAMESPACE__ . '\\add_admin_decoupled_preview_link', 100 );
-		add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_scripts', 100 );
+		add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
 	}
 
 	// We're not processing this information at all so we can bypass the nonce here.


### PR DESCRIPTION
- JS now polls for the existence of the preview button in the editor before attempting to modify it.
- Added minor styling fix to address z-index issues with sidebar panel.
- Clarified in readmes that this plugin currently only supports the block editor. (We'd need to make more changes than I had assumed in order to support the classic editor, so I'll log it as a feature and we can track demand.)

Moved PR to upstream repo to ensure actions run. You can see existing discussion here: https://github.com/pantheon-systems/wp-decoupled-preview/pull/45