### PR TITLE
Add a test against the latest WordPress nightly version

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -21,6 +21,8 @@ jobs:
           php -v
           mysqladmin -V
           bash .bin/install-wp-tests.sh wordpress_test root root localhost latest
+          rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+          bash .bin/install-wp-tests.sh wordpress_test root root localhost nightly true
       - name: Run linter
         run: composer lint
       - name: Run tests


### PR DESCRIPTION
This PR adds another run-through of the test suite using the latest nightly version of WP.

See: https://github.com/pantheon-systems/cms-platform/discussions/45