### PR TITLE
DB-6462: Associate user with a preview site

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -10,7 +10,7 @@ Pull requests and issues are welcome!
 
 Development and releases are structured around two branches, `develop` and `main`. The `develop` branch is the default branch for the repository, and is the source and destination for feature branches.
 
-We prefer to squash commits (i.e. avoid merge PRs) from a feature branch into `develop` when merging, and to include the PR # in the commit message. PRs to `develop` should also include any relevent updates to the changelog in readme.txt. For example, if a feature constitutes a minor or major version bump, that version update should be discussed and made as part of approving and merging the feature into `develop`.
+We prefer to squash commits (i.e. avoid merge PRs) from a feature branch into `develop` when merging, and to include the PR # in the commit message. PRs to `develop` should also include any relevant updates to the changelog in readme.txt. For example, if a feature constitutes a minor or major version bump, that version update should be discussed and made as part of approving and merging the feature into `develop`.
 
 `develop` should be stable and usable, though possibly a few commits ahead of the public release on wp.org.
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,11 +2,7 @@
 Contributors: getpantheon, backlineint, abhisekmazumdar, jspellman,jazzs3quence
 Tags: headless,next.js,decoupled,preview
 Tested up to: 6.2.2
-<<<<<<< HEAD
 Stable tag: 1.0.4-dev
-=======
-Stable tag: 1.0.3-dev
->>>>>>> 30bb42b7e7dd43a47abab8de7c314976e32f3702
 License: GPL2 or later
 License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
 

--- a/src/class-decoupled-preview-settings.php
+++ b/src/class-decoupled-preview-settings.php
@@ -78,7 +78,7 @@ if ( ! class_exists( __NAMESPACE__ . '\\Decoupled_Preview_Settings' ) ) {
 				'wp-decoupled-preview-section'
 			);
 			add_settings_field(
-				'plugin_text_user',
+				'plugin_dropdown_user',
 				esc_html__( 'Associated User', 'wp-decoupled-preview' ),
 				[ &$this, 'setting_associated_user_fn' ],
 				'preview_sites',
@@ -343,7 +343,7 @@ if ( ! class_exists( __NAMESPACE__ . '\\Decoupled_Preview_Settings' ) ) {
 				$sanitized_input['secret_string'] = sanitize_text_field( $input['secret_string'] );
 			}
 			if ( empty( $input['associated_user'] ) ) {
-				$sanitized_input['associated_user'] = '--None--';
+				$sanitized_input['associated_user'] = '';
 			} else {
 				$sanitized_input['associated_user'] = sanitize_text_field( $input['associated_user'] );
 			}
@@ -584,7 +584,7 @@ if ( ! class_exists( __NAMESPACE__ . '\\Decoupled_Preview_Settings' ) ) {
 				?>
 				<label for="associated_user">Choose an associated user:</label>
 				<select id="associated_user" name="preview_sites[associated_user]" autocomplete="username">
-					<option value="" selected="<?php $site['associated_user'] === '--None--'; ?>">--None--</option>
+					<option value="" selected="<?php $site['associated_user'] === ''; ?>">--None--</option>
 					<?php
 					foreach ( $users as $user ) {
 						$selected = ( $site['associated_user'] === $user->display_name ) ? 'selected="selected"' : '';

--- a/src/class-decoupled-preview-settings.php
+++ b/src/class-decoupled-preview-settings.php
@@ -78,6 +78,13 @@ if ( ! class_exists( __NAMESPACE__ . '\\Decoupled_Preview_Settings' ) ) {
 				'wp-decoupled-preview-section'
 			);
 			add_settings_field(
+				'plugin_text_user',
+				esc_html__( 'Associated User', 'wp-decoupled-preview' ),
+				[ &$this, 'setting_associated_user_fn' ],
+				'preview_sites',
+				'wp-decoupled-preview-section'
+			);
+			add_settings_field(
 				'plugin_hidden',
 				'',
 				[ &$this, 'setting_hidden_fn' ],
@@ -335,6 +342,11 @@ if ( ! class_exists( __NAMESPACE__ . '\\Decoupled_Preview_Settings' ) ) {
 			if ( isset( $input['secret_string'] ) ) {
 				$sanitized_input['secret_string'] = sanitize_text_field( $input['secret_string'] );
 			}
+			if ( empty( $input['associated_user'] ) ) {
+				$sanitized_input['associated_user'] = '--None--';
+			} else {
+				$sanitized_input['associated_user'] = sanitize_text_field( $input['associated_user'] );
+			}
 			$edit_id = ! isset( $edit_id ) || $edit_id !== $sanitized_input['id'] ? $sanitized_input['id'] : $edit_id;
 
 			$options['preview'][ $edit_id ] = $sanitized_input;
@@ -556,6 +568,34 @@ if ( ! class_exists( __NAMESPACE__ . '\\Decoupled_Preview_Settings' ) ) {
 			?>
 			<input id="plugin_hidden" name="preview_sites[id]" size="40" type="hidden" value="<?php echo $edit_id ? absint( $edit_id ) : ''; ?>" />
 			<?php
+		}
+
+		/**
+		 * Associated User
+		 * 
+		 * @return void
+		 */
+		public function setting_associated_user_fn() {
+			check_admin_referer( 'edit-preview-site', 'nonce' );
+			$edit_id = isset( $_GET['id'] ) ? sanitize_text_field( $_GET['id'] ) : false;
+			$site = $this->get_preview_site( $edit_id );
+			$users = get_users( [ 'fields' => [ 'display_name' ] ] );
+			if ( isset( $edit_id ) ) {
+				?>
+				<label for="associated_user">Choose an associated user:</label>
+				<select id="associated_user" name="preview_sites[associated_user]" autocomplete="username">
+					<option value="" selected="<?php $site['associated_user'] === '--None--'; ?>">--None--</option>
+					<?php
+					foreach ( $users as $user ) {
+						$selected = ( $site['associated_user'] === $user->display_name ) ? 'selected="selected"' : '';
+						?>
+						<option value="<?php echo esc_attr( $user->display_name ); ?>" <?php echo esc_attr( $selected ); ?>><?php echo esc_html( $user->display_name ); ?></option>
+						<?php
+					}
+					?>
+				</select>
+				<?php
+			}
 		}
 
 		/**

--- a/src/class-list-table.php
+++ b/src/class-list-table.php
@@ -97,6 +97,7 @@ class List_Table extends WP_List_table {
 			'url' => __( 'URL', 'wp-decoupled-preview' ),
 			'preview_type' => __( 'Preview Type', 'wp-decoupled-preview' ),
 			'content_type' => __( 'Content Type', 'wp-decoupled-preview' ),
+			'associated_user' => __( 'Associated User', 'wp-decoupled-preview' ),
 			'actions' => __( 'Actions', 'wp-decoupled-preview' ),
 		];
 	}
@@ -112,6 +113,7 @@ class List_Table extends WP_List_table {
 		switch ( $column_name ) {
 			case 'label':
 			case 'url':
+			case 'associated_user':
 			case 'preview_type':
 				return isset( $item[ $column_name ] ) ? esc_html( $item[ $column_name ] ) : '';
 			case 'content_type':

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -39,6 +39,7 @@ function _get_test_sites() : array {
 			'url' => 'https://example.com/api/preview',
 			'secret_string' => 'secret',
 			'preview_type' => 'Next.js',
+			'associated_user' => '',
 			'id' => 1,
 		],
 		2 => [
@@ -47,6 +48,7 @@ function _get_test_sites() : array {
 			'secret_string' => 'test',
 			'preview_type' => 'Next.js',
 			'content_type' => [ 'post' ],
+			'associated_user' => 'admin',
 			'id' => 2,
 		],
 		3 => [
@@ -55,6 +57,7 @@ function _get_test_sites() : array {
 			'secret_string' => 'test',
 			'preview_type' => 'Next.js',
 			'content_type' => [ 'page' ],
+			'associated_user' => 'admin',
 			'id' => 3,
 		],
 	];

--- a/tests/test-decoupled-preview-settings.php
+++ b/tests/test-decoupled-preview-settings.php
@@ -215,6 +215,7 @@ class Test_Settings extends WP_UnitTestCase {
 						'url' => 'https://example.com/api/preview',
 						'secret_string' => 'secret',
 						'preview_type' => 'Next.js',
+						'associated_user' => '',
 						'id' => 1,
 					],
 					[
@@ -223,6 +224,7 @@ class Test_Settings extends WP_UnitTestCase {
 						'secret_string' => 'test',
 						'preview_type' => 'Next.js',
 						'content_type' => [ 'post' ],
+						'associated_user' => 'admin',
 						'id' => 2,
 					],
 				],
@@ -235,6 +237,7 @@ class Test_Settings extends WP_UnitTestCase {
 						'url' => 'https://example.com/api/preview',
 						'secret_string' => 'secret',
 						'preview_type' => 'Next.js',
+						'associated_user' => '',
 						'id' => 1,
 					],
 					[
@@ -243,6 +246,7 @@ class Test_Settings extends WP_UnitTestCase {
 						'secret_string' => 'test',
 						'preview_type' => 'Next.js',
 						'content_type' => [ 'page' ],
+						'associated_user' => 'admin',
 						'id' => 3,
 					],
 				],

--- a/tests/test-list-table.php
+++ b/tests/test-list-table.php
@@ -78,7 +78,7 @@ class Test_List_Table extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_column_default( $expected_result, $input ) : void {
-		$columns = [ 'label', 'url', 'preview_type', 'content_type', '' ];
+		$columns = [ 'label', 'url', 'preview_type', 'content_type', 'associated_user', '' ];
 
 		foreach ( $columns as $column ) {
 			$this->assertEquals( $this->list_table->column_default( $input, $column ), $expected_result[ $column ] );
@@ -99,6 +99,7 @@ class Test_List_Table extends WP_UnitTestCase {
 					'url' => 'https://example.com/api/preview',
 					'preview_type' => 'Next.js',
 					'content_type' => 'Post, Page',
+					'associated_user' => '',
 					'' => '',
 				],
 				'input' => $data[1],
@@ -109,6 +110,7 @@ class Test_List_Table extends WP_UnitTestCase {
 					'url' => 'https://test-site.pantheonsite.io',
 					'preview_type' => 'Next.js',
 					'content_type' => 'Post',
+					'associated_user' => 'admin',
 					'' => '',
 				],
 				'input' => $data[2],
@@ -119,6 +121,7 @@ class Test_List_Table extends WP_UnitTestCase {
 					'url' => 'https://test-site-2.pantheonsite.io',
 					'preview_type' => 'Next.js',
 					'content_type' => 'Page',
+					'associated_user' => 'admin',
 					'' => '',
 				],
 				'input' => $data[3],

--- a/tests/test-main.php
+++ b/tests/test-main.php
@@ -63,6 +63,8 @@ class Test_Main extends WP_UnitTestCase {
 		$this->assertEquals( 'Next.js', $options['preview'][1]['preview_type'] );
 		$this->assertArrayHasKey( 'id', $options['preview'][1] );
 		$this->assertEquals( 1, $options['preview'][1]['id'] );
+		$this->assertArrayHasKey( 'associated_user', $options['preview'][1] );
+		$this->assertEquals( '', $options['preview'][1]['associated_user'] );
 
 		// Delete the options.
 		delete_default_options();

--- a/wp-decoupled-preview.php
+++ b/wp-decoupled-preview.php
@@ -89,6 +89,7 @@ function set_default_options() {
 					'url' => 'https://example.com/api/preview',
 					'secret_string' => $secret,
 					'preview_type' => 'Next.js',
+					'associated_user' => '',
 					'id' => 1,
 				],
 			],


### PR DESCRIPTION
Initial work to add a dropdown to the Preview Site setting which enables a user to be associated with the preview site.

~~⚠️ Tests have not been updated yet!~~
Tried updating the tests :)

There are still 2 things in the AC I'm not 100% sure of:
> 1. This field will be added during new installs of the plugin.
> 2. This field will also be added for existing installations of the decoupled-preview plugin that upgrade to the most recent version.

1. I'm kind of assuming this will just happen? The field seems to be there when I am using the version of the plugin I am developing on with no extra steps but please correct me if I'm wrong
2. Same here, but I'm less certain. Pretty sure the `add_settings_field` does the trick but I haven't been able to properly test this yet.

Some minor typos fixed in the readme.txt as well.