### PR TITLE
DB-6464: Move set default preview site functionality to `wp-pantheon-decoupled`

### DIFF
--- a/tests/test-main.php
+++ b/tests/test-main.php
@@ -31,46 +31,4 @@ class Test_Main extends WP_UnitTestCase {
 	public function test_class_exists() : void {
 		$this->assertTrue( class_exists( __NAMESPACE__ . '\\Decoupled_Preview_Settings' ) );
 	}
-
-	/**
-	 * Test the set_default_options() and delete_default_options() functions.
-	 *
-	 * @covers \Pantheon\DecoupledPreview\set_default_options()
-	 * @covers \Pantheon\DecoupledPreview\delete_default_options()
-	 *
-	 * @return void
-	 */
-	public function test_default_options() : void {
-		// Set the default options.
-		set_default_options();
-		$options = get_option( 'preview_sites' );
-		$this->assertNotEmpty( $options );
-
-		// Ensure that the transient was set.
-		$transient = get_transient( 'example_preview_password' );
-		$this->assertNotEmpty( $transient );
-
-		// Ensure that the options were set.
-		$this->assertNotEmpty( $options );
-		$this->assertArrayHasKey( 'preview', $options );
-		$this->assertArrayHasKey( 'label', $options['preview'][1] );
-		$this->assertEquals( 'Example NextJS Preview', $options['preview'][1]['label'] );
-		$this->assertArrayHasKey( 'url', $options['preview'][1] );
-		$this->assertEquals( 'https://example.com/api/preview', $options['preview'][1]['url'] );
-		$this->assertArrayHasKey( 'secret_string', $options['preview'][1] );
-		$this->assertEquals( $transient, $options['preview'][1]['secret_string'] );
-		$this->assertArrayHasKey( 'preview_type', $options['preview'][1] );
-		$this->assertEquals( 'Next.js', $options['preview'][1]['preview_type'] );
-		$this->assertArrayHasKey( 'id', $options['preview'][1] );
-		$this->assertEquals( 1, $options['preview'][1]['id'] );
-		$this->assertArrayHasKey( 'associated_user', $options['preview'][1] );
-		$this->assertEquals( '', $options['preview'][1]['associated_user'] );
-
-		// Delete the options.
-		delete_default_options();
-		$options = get_option( 'preview_sites' );
-
-		// Ensure that the options were deleted.
-		$this->assertEmpty( $options );
-	}
 }

--- a/wp-decoupled-preview.php
+++ b/wp-decoupled-preview.php
@@ -37,7 +37,6 @@ function bootstrap() {
 	new Decoupled_Preview_Settings();
 
 	add_action( 'init', __NAMESPACE__ . '\\conditionally_enqueue_scripts' );
-	add_action( 'admin_notices', __NAMESPACE__ . '\\show_example_preview_password_admin_notice' );
 	add_action( 'updated_option', __NAMESPACE__ . '\\redirect_to_preview_site' );
 
 	// Register activation and deactivation hooks.
@@ -69,65 +68,6 @@ function conditionally_enqueue_scripts() {
 		// Return custom preview template where we can handle redirect.
 		add_filter( 'template_include', __NAMESPACE__ . '\\override_preview_template', 1 );
 	}
-}
-
-/**
- * Set default values for the preview sites options.
- *
- * @return void
- */
-function set_default_options() {
-	$secret = wp_generate_password( 10, false );
-	set_transient( 'example_preview_password', $secret );
-
-	add_option(
-		'preview_sites',
-		[
-			'preview' => [
-				1 => [
-					'label' => esc_html__( 'Example NextJS Preview', 'wp-decoupled-preview' ),
-					'url' => 'https://example.com/api/preview',
-					'secret_string' => $secret,
-					'preview_type' => 'Next.js',
-					'associated_user' => '',
-					'id' => 1,
-				],
-			],
-		]
-	);
-}
-
-/**
- * Show example preview password admin notice.
- *
- * @return void
- */
-function show_example_preview_password_admin_notice() {
-	$preview_password = get_transient( 'example_preview_password' );
-	if ( $preview_password ) {
-		?>
-		<div class="notice notice-success notice-alt below-h2 is-dismissible">
-			<strong><?php esc_html_e( 'Pantheon Decoupled Preview Example', 'wp-decoupled-preview' ); ?></strong>
-			<p class="decoupled-preview-example">
-				<label for="new-decoupled-preview-example-value">
-					<?php echo wp_kses( __( 'The shared secret of the <strong>Example NextJS Preview</strong> site is:', 'wp-decoupled-preview' ), [ 'strong' => [] ] ); ?>
-				</label>
-				<input type="text" class="code" value="<?php printf( esc_attr( get_transient( 'example_preview_password' ) ) ); ?>" />
-			</p>
-			<p><?php esc_html_e( 'Be sure to save this in a safe location. You will not be able to retrieve it.', 'wp-decoupled-preview' ); ?></p>
-		</div>
-		<?php
-		delete_transient( 'example_preview_password' );
-	}
-}
-
-/**
- * Delete preview sites options when deactivation plugin.
- *
- * @return void
- */
-function delete_default_options() {
-	delete_option( 'preview_sites' );
 }
 
 /**


### PR DESCRIPTION
Moved the following functions to the pantheon-decoupled plugin: set_default_options, delete_default_options, show_example_preview_password_admin_notice

See https://github.com/pantheon-systems/wp-pantheon-decoupled/pull/33