### PR TITLE
[JFDI] Run lint-test on PR instead of on push

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,5 +1,5 @@
 name: WP Decoupled Preview Lint
-on: push
+on: pull_request
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Triggering actions on PR should allow approving github actions to run on PRs opened from forks.