### PR TITLE
DB-6671: Preview Button Regression in WordPress 6.3

### DIFF
--- a/css/add-icon.css
+++ b/css/add-icon.css
@@ -23,3 +23,8 @@
 .interface-z-index-0 {
 	z-index: 0;
 }
+
+/* When decoupled preview is enabled, never display the standard preview button */
+.block-editor-post-preview__dropdown.decoupled-preview button.block-editor-post-preview__button-toggle {
+  display: none;
+}

--- a/js/add-new-preview-btn.js
+++ b/js/add-new-preview-btn.js
@@ -14,10 +14,12 @@ window.addEventListener(
     // Ensure that block editor preview button exists, and if so, modify it.
     const checkPreview = () => {
       const previewBlock = document.querySelector( ".block-editor-post-preview__dropdown" );
+      // Add a class to allow us to scope styles that apply to the default
+      // preview button, only when the Decoupled Preview button is present.
+      previewBlock.classList.add( "decoupled-preview" );
       const decoupledPreviewBtn = document.getElementById( 'wp-admin-bar-decoupled-preview' );
       // Remove the old Preview button.
       if (previewBlock) {
-        previewBlock.removeChild( previewBlock.querySelector( 'button' ) );
         // Add Decoupled Preview Button into the same Preview container.
         previewBlock.appendChild( decoupledPreviewBtn );
         // Hide submenu items by default.


### PR DESCRIPTION
In WordPress 6.3 dispatching an autosave event in the block editor via JS now triggers additional actions by WordPress that expect the default preview button to exist. This was causing React to throw an exception in the block editor.

In order to resolve this, we're now hiding the standard preview button with CSS rather than removing it from the dom via JS.

I also took a long look at adding test coverage for this. Since this functionality depends on client side JS our existing suite of PHP unit tests won't help. From what I can tell, WordPress does not have a core solution for functional or browser tests. The only JS testing is JQuery unit testing, which I also don't think can cover this use case. wp-browser (https://wpbrowser.wptestkit.dev/) seems like it would meet our needs, but the implementation would be outside the scope of this ticket. wp-browser uses codeception rather than phpunit, and assumes that a live WordPress environment already exists.

We have an upcoming need for End to End testing, so I think that would be the most efficient way to address this.

Long term:
* We could take on the effort to implement browser based testing.
* or refactor the plugin to handle more of these changes on the server side. Our client side approach has proven to be brittle.