### PR TITLE
Remove broken and unused activate/deactivate hooks

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -57,6 +57,7 @@ This plugin currently only supports the block editor.
 
 ** Latest **
 * Updates Pantheon WP Coding Standards to 2.0 [[#63](https://github.com/pantheon-systems/wp-decoupled-preview/pull/63)]
+* Fixes an issue with broken activation and deactivation hooks
 
 = 1.0.5 =
 * Preview Button Regression in WordPress 6.3. [[#58](https://github.com/pantheon-systems/wp-decoupled-preview/pull/58)]

--- a/wp-decoupled-preview.php
+++ b/wp-decoupled-preview.php
@@ -38,10 +38,6 @@ function bootstrap() {
 
 	add_action( 'init', __NAMESPACE__ . '\\conditionally_enqueue_scripts' );
 	add_action( 'updated_option', __NAMESPACE__ . '\\redirect_to_preview_site' );
-
-	// Register activation and deactivation hooks.
-	register_activation_hook( __FILE__, __NAMESPACE__ . '\\set_default_options' );
-	register_deactivation_hook( __FILE__, __NAMESPACE__ . '\\delete_default_options' );
 }
 
 /**


### PR DESCRIPTION
Reports of the Decoupled WordPress upstream failing to initialize this plugin have surfaced and this is likely the culprit.
