### PR TITLE
add svn for lint-test workflow

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -9,13 +9,15 @@ jobs:
       DB_PASSWORD: root
       DB_HOST: localhost
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Composer dependencies
         run: composer install
       - name: Setup MySQL
         run: |
           sudo /etc/init.d/mysql start
           mysql -e 'SHOW DATABASES;' -uroot -proot
+      - name: Install SVN
+        run: sudo apt-get update && sudo apt-get install -y subversion
       - name: Install WP Unit tests
         run: |
           php -v


### PR DESCRIPTION
SVN was removed from `ubuntu-latest` but we need it for our WP unit tests. This adds it back.

**Note:** This project is not using [wpunit-helpers](https://github.com/pantheon-systems/wpunit-helpers) and, given the status of the project, I'm unlikely to recommend adding it to the repo at this time.